### PR TITLE
Bugfix: extra argument breaks in runtime

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -230,7 +230,6 @@ def chunk_gated_delta_rule(
         initial_state,
         output_final_state,
         cu_seqlens,
-        use_qk_l2norm_in_kernel,
     )
 
     return o, final_state


### PR DESCRIPTION
Deleted redundant argument passed to ChunkGatedDeltaRuleFunction, which caused TypeError as-is. I guess there are future plans for incorporating qk norm actually inside the kernel or it's there just for compatibility with FLA, either way wasn't working that way, so here's a quickfix