### PR TITLE
[Fix] fix module error upon non-editable installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import os
 import subprocess
-from setuptools import setup
+from setuptools import setup, find_packages
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -19,7 +19,7 @@ setup(
     name="flash_qla",
     version="0.1.0" + rev,
     description="FlashQLA: Fused TileLang kernels for Linear Attention",
-    packages=["flash_qla"],
+    packages=find_packages(),
     license="MIT",
     python_requires=">=3.10",
     install_requires=[


### PR DESCRIPTION
# Bug Report
`pip install .`(non-editable) only copied `flash_qla/__init__.py` to `site-packages` because `setup.py` hardcoded `packages=["flash_qla"]`, causing `ModuleNotFoundError` when importing subpackages like `flash_qla.ops / flash_qla.utils`.

To reproduce this bug, run non-editable installation, and `python -c "import flash_qla"` anywhere other than repo root.
Editable installation is not affected.

This actually causes test examples in  [README](https://github.com/QwenLM/FlashQLA#tests) to fail directly with `ModuleNotFound` error since they are run in `tests/` directory.

# Solution (This PR)
Replaced the hardcoded package list with find_packages() so setuptools automatically discovers and includes all subpackages.
