### PR TITLE
Bugfix: UnboundLocalError when auto_cp=False

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -45,6 +45,9 @@ def chunk_gated_delta_rule_fwd(
                 raw_cu_seqlens=cu_seqlens,
             )
         )
+    else:
+        cp_seq_map = None
+        raw_cu_seqlens = None
     o, h, final_state = fused_gdr_fwd(
         q=q,
         k=k,


### PR DESCRIPTION
## Summary

`chunk_gated_delta_rule_fwd` in `flash_qla/ops/gated_delta_rule/chunk/__init__.py` raises `UnboundLocalError` when called with `auto_cp=False`. `cp_seq_map` and `raw_cu_seqlens` are only assigned inside the `if auto_cp:` block (lines 36-47), but referenced unconditionally at lines 61-62.

The flag is reachable from `tests/test_gdr.py` via `--no-cp` (parser at lines 495-499; passed through at line 535).

## Reproduction

```
$ python tests/test_gdr.py --set develop --no-cp
...
UnboundLocalError: cannot access local variable 'cp_seq_map' where it is not associated with a value
```

A GPU-free reproduction mirroring the function's branch structure exhibits the same error.

## Fix

Add an `else:` branch that initializes both names to `None`. This matches the existing contract of `fused_gdr_fwd` (`hopper/fused_fwd.py:545-546`), which already declares both arguments as `Optional` and handles the `None` case at lines 573-588. It also matches the two early-return paths in `intra_card_cp_preprocess` (`cp_context.py:122,134`) which already return `(raw_h0, raw_cu_seqlens, None, None)` when CP is bypassed.

```python
if auto_cp:
    initial_state, cu_seqlens, cp_seq_map, raw_cu_seqlens = (
        intra_card_cp_preprocess(...)
    )
else:
    cp_seq_map = None
    raw_cu_seqlens = None
```

## Test plan

- [x] `python tests/test_gdr.py --set develop --no-cp` no longer raises `UnboundLocalError`
- [x] `python tests/test_gdr.py --set develop` (default `auto_cp=True`) unchanged
