### PR TITLE
Bugfix: ChunkGatedDeltaRuleFunction.backward returns wrong number of gradients

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -174,7 +174,6 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             dh0,
             None,
             None,
-            None,
         )
 
 

--- a/tests/test_function_signature.py
+++ b/tests/test_function_signature.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+"""Static checks for autograd ``Function`` signatures.
+
+PyTorch validates that ``Function.backward`` returns exactly as many gradients
+as ``Function.forward`` received non-``ctx`` inputs; mismatches raise at
+``.backward()`` time.  ``tests/test_gdr.py`` invokes ``chunk_gated_delta_rule_fwd``
+and ``chunk_gated_delta_rule_bwd`` directly, bypassing the autograd path, so
+drift between the forward signature and the backward return tuple goes
+uncaught by the existing suite.
+
+These tests parse the source files with ``ast`` instead of importing the
+modules so they run on CPU-only / non-Hopper machines.
+"""
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHUNK_INIT = "flash_qla/ops/gated_delta_rule/chunk/__init__.py"
+
+
+def _parse(rel_path: str) -> ast.Module:
+    return ast.parse((REPO_ROOT / rel_path).read_text(encoding="utf-8"))
+
+
+def _get_class(module: ast.Module, name: str) -> ast.ClassDef:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name!r} not found")
+
+
+def _get_method(cls: ast.ClassDef, name: str) -> ast.FunctionDef:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"method {name!r} not found on {cls.name}")
+
+
+def test_chunk_gated_delta_rule_grad_count_matches_forward_inputs():
+    """``backward`` must return one gradient per non-``ctx`` input of ``forward``."""
+    module = _parse(CHUNK_INIT)
+    cls = _get_class(module, "ChunkGatedDeltaRuleFunction")
+
+    fwd = _get_method(cls, "forward")
+    fwd_args = fwd.args.args
+    assert fwd_args and fwd_args[0].arg == "ctx", (
+        "forward must take `ctx` as its first argument"
+    )
+    n_inputs = len(fwd_args) - 1  # exclude ctx
+
+    bwd = _get_method(cls, "backward")
+    returns = [n for n in ast.walk(bwd) if isinstance(n, ast.Return)]
+    assert len(returns) == 1, f"expected one Return in backward, got {len(returns)}"
+    assert isinstance(returns[0].value, ast.Tuple), (
+        "backward must return a tuple literal"
+    )
+    n_grads = len(returns[0].value.elts)
+
+    assert n_inputs == n_grads, (
+        f"backward returns {n_grads} gradients but forward takes {n_inputs} non-ctx "
+        f"inputs; PyTorch will raise a count-mismatch error at .backward() time."
+    )
+
+
+if __name__ == "__main__":
+    test_chunk_gated_delta_rule_grad_count_matches_forward_inputs()
+    print("OK")


### PR DESCRIPTION
## Summary

`ChunkGatedDeltaRuleFunction.forward` (`flash_qla/ops/gated_delta_rule/chunk/__init__.py`) takes 9 non-`ctx` inputs:

```
q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens
```

but `.backward` returns a **10**-tuple. PyTorch enforces that a custom `autograd.Function`'s backward returns exactly as many gradients as `forward` received non-`ctx` inputs, so any user calling `loss.backward()` through the public `chunk_gated_delta_rule(...)` API hits:

```
RuntimeError: function ChunkGatedDeltaRuleFunctionBackward returned an incorrect number of gradients (expected 9, got 10)
```

The trailing `None` is stale; signature drift in `.backward` predates #1 (which fixed the `Function.apply(...)` call site after `use_qk_l2norm_in_kernel` was removed) but `.backward` itself was never updated. Same bug class as #8 — drift across a refactor that wasn't propagated end-to-end.

## Why it stayed latent

`tests/test_gdr.py` invokes `chunk_gated_delta_rule_fwd_qla` / `chunk_gated_delta_rule_bwd_qla` directly (lines 18-19, 172-184) and never goes through the autograd `Function`, so the existing suite cannot exercise the `apply` → `.backward()` path. There is no CI on the repo yet.

## Fix

Drop the stale trailing `None` so `.backward` returns 9 gradients matching the 9 non-`ctx` forward inputs:

```python
return (
    dq.to(q_orig),     # q
    dk.to(k_orig),     # k
    dv.to(v),          # v
    dg.to(g),          # g
    db.to(beta),       # beta
    None,              # scale
    dh0,               # initial_state
    None,              # output_final_state
    None,              # cu_seqlens
)
```

## Regression test

Adds `tests/test_function_signature.py` — a CPU-only, `ast`-based check that parses the source file and asserts `len(backward return tuple) == len(forward args) - 1` (excluding `ctx`). It runs without CUDA / TileLang / SM90 hardware, so it can be invoked anywhere and would have caught both the original drift and any future drift of the same shape.

## Test plan

- [x] `python tests/test_function_signature.py` → `OK` after the fix
- [x] Same test fails before the fix with the exact diagnostic:
      `backward returns 10 gradients but forward takes 9 non-ctx inputs; PyTorch will raise a count-mismatch error at .backward() time.`
- [x] `ruff check` and `ruff format --check` clean on both changed files
- [ ] Maintainers confirm on a SM90 box that `chunk_gated_delta_rule(...).sum().backward()` no longer raises the count-mismatch RuntimeError (I do not have Hopper hardware to run the kernel path end-to-end)