### PR TITLE
Fix: preserve input dtype in l2norm helper

### DIFF
--- a/flash_qla/utils/math.py
+++ b/flash_qla/utils/math.py
@@ -7,7 +7,7 @@ import torch
 @torch.compile
 def l2norm_compiled(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
     inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
-    return x * inv_norm
+    return (x * inv_norm).to(x.dtype)
 
 
 def l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):


### PR DESCRIPTION
## Summary

`l2norm_compiled` silently upcasts `bf16 → fp32` because of how `@torch.compile` handles the `rsqrt(sum(x*x) + eps)` chain. 

https://github.com/QwenLM/FlashQLA/blob/e88d71a1473d1479083413913f25dec018404ce4/flash_qla/utils/math.py#L7-L10

This breaks any caller that uses `use_qk_l2norm_in_kernel=True` with `bf16` inputs:

https://github.com/QwenLM/FlashQLA/blob/e88d71a1473d1479083413913f25dec018404ce4/flash_qla/ops/gated_delta_rule/chunk/__init__.py#L219-L221

## Bug

After the `l2norm` calls above, `q.dtype` no longer equals `v.dtype`. The fused fwd kernel then keys `qkva_dtype` on `q.dtype` (`fp32`) and rejects `v` (`bf16`) at runtime:

```
RuntimeError: kernel tilelang_fused_chunk_gdr_fwd_kernel input v dtype expected float32, but got bfloat16
```

## Why it upcasts

Under `@torch.compile`, Inductor keeps the reduction + `rsqrt` intermediates in `fp32` for numerical stability, so `inv_norm` is `fp32`. PyTorch type promotion then turns `bf16 * fp32 → fp32`, and the function returns `fp32` even though the input was `bf16`. The promotion is invisible in eager mode but materializes in the compiled graph.

## Reproducer

The trigger is the combination of `bf16` inputs, `requires_grad=True`, and an active `torch.amp.autocast(bf16)` context, bare bf16 tensors without autocast do **not** fail (l2norm only upcasts when traced under autocast).

```python
import torch
from flash_qla import chunk_gated_delta_rule

B, T, Hq, Hv, D = 2, 256, 3, 6, 128
dtype, dev = torch.bfloat16, "cuda"
q = torch.randn(B, T, Hq, D, dtype=dtype, device=dev, requires_grad=True)
k = torch.randn(B, T, Hq, D, dtype=dtype, device=dev, requires_grad=True)
v = torch.randn(B, T, Hv, D, dtype=dtype, device=dev, requires_grad=True)
g = torch.randn(B, T, Hv, dtype=dtype, device=dev, requires_grad=True)
beta = torch.rand(B, T, Hv, dtype=dtype, device=dev).sigmoid().detach().requires_grad_(True)

with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
    # Fails: input v dtype expected float32, but got bfloat16
    chunk_gated_delta_rule(q, k, v, g, beta, use_qk_l2norm_in_kernel=True)
```

## Fix

One line — cast the result back to the input dtype at the end of `l2norm_compiled`:

```diff
 @torch.compile
 def l2norm_compiled(x, dim=-1, eps=1e-6):
     inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
-    return x * inv_norm
+    return (x * inv_norm).to(x.dtype)
```

The `fp32` intermediates inside the compiled region are kept (good for precision); only the user-visible boundary is restored to the input dtype.

## Verification

Validated on H100 with a hybrid GDN training run.
