### PR TITLE
Add Blackwell GDN fused backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ python test_gdr.py --set product --ref-dtype float32 --num-heads 32
 
 ## Benchmark
 
-We benchmarked FlashQLA against the FLA Triton and FlashInfer baseline (FLA 0.5.0, Triton 3.5.1, FlashInfer 0.6.9, TileLang 0.1.8) on the head configurations used by the Qwen3.5 / Qwen3.6 family h_k,v \in {64, 48, 32, 24, 16, 8}, corresponding to TP1 through TP8.
+We benchmarked FlashQLA against the FLA Triton and FlashInfer baseline (FLA 0.5.0, Triton 3.5.1, FlashInfer 0.6.9, TileLang 0.1.8) on the head configurations used by the Qwen3.5 / Qwen3.6 family h_k,v \in {64, 48, 32, 24, 16, 8}, corresponding to TP1 through TP8. The Blackwell/sm100 backend added after these H200 benchmarks requires TileLang 0.1.10, as pinned in `setup.py`.
 
 <p align="center">
     <img src="https://qianwen-res.oss-cn-beijing.aliyuncs.com/flashqla/fwd_bwd_latency_comparison.png" width="1000"/>

--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -7,11 +7,37 @@ import tilelang
 from flash_qla.utils import l2norm
 from flash_qla.ops.utils import chunk_local_cumsum, group_reduce_vector
 
-if tilelang.contrib.nvcc.get_target_compute_version() == "9.0":
-    from .hopper import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
-else:
-    raise ValueError("FlashQLA now support sm90 only.")
 from .cp_context import intra_card_cp_preprocess
+
+_target_compute_version = tilelang.contrib.nvcc.get_target_compute_version()
+if _target_compute_version == "9.0":
+    from .hopper import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
+
+    _chunk_backend = "hopper"
+elif _target_compute_version == "10.0":
+    from .blackwell import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
+
+    _chunk_backend = "blackwell"
+else:
+    raise ValueError("FlashQLA now supports sm90/sm100 only.")
+
+
+def _check_backend_matches_device(x: torch.Tensor):
+    if not x.is_cuda:
+        return
+    major = torch.cuda.get_device_capability(x.device)[0]
+    if major >= 10 and _chunk_backend != "blackwell":
+        raise RuntimeError(
+            "FlashQLA was imported with the SM90/Hopper TileLang target, but the "
+            "input tensor is on an SM100+ Blackwell GPU. Re-import FlashQLA with "
+            "TileLang target 10.0 enabled."
+        )
+    if major == 9 and _chunk_backend != "hopper":
+        raise RuntimeError(
+            "FlashQLA was imported with the SM100/Blackwell TileLang target, but "
+            "the input tensor is on an SM90 Hopper GPU. Re-import FlashQLA with "
+            "TileLang target 9.0 enabled."
+        )
 
 
 def chunk_gated_delta_rule_fwd(
@@ -25,8 +51,19 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     output_final_state: bool = True,
     output_h: bool = False,
-    auto_cp: bool = True,
+    auto_cp: bool | None = None,
 ):
+    _check_backend_matches_device(q)
+    sm100_or_newer = q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 10
+    if auto_cp is None:
+        auto_cp = not sm100_or_newer
+    elif auto_cp and sm100_or_newer:
+        raise RuntimeError(
+            "FlashQLA auto_cp=True is not supported on SM100+ Blackwell GPUs. "
+            "Use auto_cp=None or auto_cp=False so the Blackwell fused path runs "
+            "without context-parallel splitting."
+        )
+
     g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
     A = kkt_solve(
         k=k,
@@ -80,6 +117,7 @@ def chunk_gated_delta_rule_bwd(
     initial_state: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
 ):
+    _check_backend_matches_device(q)
     h, _, _ = fused_gdr_h(
         k=k,
         v=v,

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+from .fused_fwd import fused_gdr_fwd
+from .fused_bwd import fused_gdr_bwd
+from .prepare_h import fused_gdr_h
+from .kkt_solve import kkt_solve
+from .cp_fwd import get_warmup_chunks, correct_initial_states
+
+
+__all__ = [
+    "fused_gdr_fwd",
+    "fused_gdr_bwd",
+    "fused_gdr_h",
+    "kkt_solve",
+    "get_warmup_chunks",
+    "correct_initial_states",
+]

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/cp_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/cp_fwd.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import torch
+
+
+def _raise_blackwell_auto_cp_unsupported():
+    raise RuntimeError(
+        "FlashQLA auto_cp is not supported on SM100+ Blackwell GPUs. "
+        "Run the Blackwell fused GDN path with auto_cp disabled."
+    )
+
+
+def get_warmup_chunks(
+    g: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ht_mask: torch.Tensor,
+    chunk_size: int,
+    threshold: float,
+):
+    _raise_blackwell_auto_cp_unsupported()
+
+
+def correct_initial_states(
+    raw_h0: torch.Tensor,
+    ht_buffer: torch.Tensor,
+    mt_buffer: torch.Tensor,
+    fallback_mask: torch.Tensor,
+    seq_map_r2c: torch.Tensor,
+):
+    _raise_blackwell_auto_cp_unsupported()

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_bwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_bwd.py
@@ -1,0 +1,993 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import torch
+import tilelang
+import tilelang.language as T
+
+from flash_qla.utils import prepare_chunk_offsets
+
+
+@tilelang.jit(
+    # out_idx=[-5, -4, -3, -2, -1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
+    },
+)
+def tilelang_fused_chunk_gdr_bwd(
+    H,
+    Hg,
+    DK,
+    DV,
+    chunk_size,
+    scale,
+    accum_dtype,
+    qkva_dtype,
+    g_dtype,
+    b_dtype,
+    h_dtype,
+    o_dtype,
+    seqlen_dtype,
+    is_varlen,
+    use_dht,
+):
+    batch_size = T.dynamic("batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_chunks = T.dynamic("num_chunks")
+    block_S = chunk_size
+
+    if is_varlen:
+        q_shape = (1, num_tokens, Hg, DK)
+        k_shape = (1, num_tokens, Hg, DK)
+        v_shape = (1, num_tokens, H, DV)
+        o_shape = (1, num_tokens, H, DV)
+        a_shape = (1, num_tokens, H, chunk_size)
+        g_shape = (1, num_tokens, H)
+        b_shape = (1, num_tokens, H)
+        h_shape = (1, num_chunks, H, DK, DV)
+    else:
+        q_shape = (batch_size, num_tokens, Hg, DK)
+        k_shape = (batch_size, num_tokens, Hg, DK)
+        v_shape = (batch_size, num_tokens, H, DV)
+        o_shape = (batch_size, num_tokens, H, DV)
+        a_shape = (batch_size, num_tokens, H, chunk_size)
+        g_shape = (batch_size, num_tokens, H)
+        b_shape = (batch_size, num_tokens, H)
+        h_shape = (batch_size, num_chunks, H, DK, DV)
+    h0_shape = (batch_size, H, DK, DV)
+    ht_shape = (batch_size, H, DK, DV)
+
+    @T.prim_func
+    def tilelang_fused_chunk_gdr_bwd_kernel(
+        do: T.Tensor(o_shape, dtype=o_dtype),
+        dht: T.Tensor(ht_shape, dtype=accum_dtype),
+        q: T.Tensor(q_shape, dtype=qkva_dtype),
+        k: T.Tensor(k_shape, dtype=qkva_dtype),
+        v: T.Tensor(v_shape, dtype=qkva_dtype),
+        a: T.Tensor(a_shape, dtype=qkva_dtype),
+        g: T.Tensor(g_shape, dtype=g_dtype),
+        b: T.Tensor(b_shape, dtype=b_dtype),
+        h: T.Tensor(h_shape, dtype=h_dtype),
+        cu_seqlens: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        chunk_offsets: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        dq: T.Tensor(v_shape, dtype=qkva_dtype),
+        dk: T.Tensor(v_shape, dtype=qkva_dtype),
+        dv: T.Tensor(v_shape, dtype=qkva_dtype),
+        dg: T.Tensor(g_shape, dtype=g_dtype),
+        db: T.Tensor(b_shape, dtype=b_dtype),
+        dh0: T.Tensor(h0_shape, dtype=accum_dtype),
+    ):
+        with T.Kernel(batch_size * H, threads=512) as (bbh,):
+            bb, bh = bbh // H, bbh % H
+            bhg = bh // (H // Hg)
+
+            batch_idx = T.alloc_var("int32")
+            seq_start_idx = T.alloc_var("int32")
+            seq_end_idx = T.alloc_var("int32")
+            chunk_start_idx = T.alloc_var("int32")
+            batch_idx = 0 if is_varlen else bb
+            seq_start_idx = cu_seqlens[bb] if is_varlen else 0
+            seq_end_idx = cu_seqlens[bb + 1] if is_varlen else num_tokens
+            chunk_start_idx = chunk_offsets[bb] if is_varlen else 0
+
+            num_iters = T.alloc_var("int32")
+            num_iters = T.ceildiv(seq_end_idx - seq_start_idx, block_S)
+
+            # 2+2+2+2 + 1 + 4 = 13 units
+            do_shared = T.alloc_shared((block_S, DV), dtype=o_dtype)
+            q_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            k_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            v_shared = T.alloc_shared((block_S, DV), dtype=qkva_dtype)
+            a_shared = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
+            h_shared = T.alloc_shared((DK, DV), dtype=h_dtype)
+            g_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            g_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            g_rev_exp_shared = T.alloc_shared(
+                (block_S), dtype=accum_dtype, scope="shared"
+            )
+            b_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+
+            # 2 units
+            dqkv_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            dg_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            db_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            dg_vec_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            dg_col_vec_shared = T.alloc_shared(
+                (block_S), dtype=accum_dtype, scope="shared"
+            )
+
+            # 1+1 + 2+2+2 + 4 = 12 units
+            tmp_shared_1_1 = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
+            tmp_shared_1_2 = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
+            tmp_shared_2_1 = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            tmp_shared_2_2 = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            tmp_shared_2_3 = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            tmp_shared_4_1 = T.alloc_shared((DK, DV), dtype=qkva_dtype)
+
+            # CONSUMER_K
+            dk_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            dv_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            odot_fragment_1 = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            dg_fragment_1 = T.alloc_fragment((block_S), dtype=accum_dtype)
+            dg_last_local_1 = T.alloc_fragment((1), dtype=accum_dtype)
+
+            # CONSUMER_A
+            mask_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            p_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            a_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            dp_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            da_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            u_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            dq_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            db_fragment = T.alloc_fragment((block_S), dtype=accum_dtype)
+            odot_fragment_2 = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            dg_fragment_2 = T.alloc_fragment((block_S), dtype=accum_dtype)
+            dg_col_fragment_2 = T.alloc_fragment((block_S), dtype=accum_dtype)
+
+            # CONSUMER_S
+            dh_fragment = T.alloc_fragment((DK, DV), dtype=accum_dtype)
+            _odot_fragment_3 = T.alloc_fragment((DK, DV), dtype=accum_dtype)
+            reduce_fragment = T.alloc_fragment((128, 2), dtype=accum_dtype)
+            dg_last_local_3 = T.alloc_fragment((1), dtype=accum_dtype)
+            g_last_local_3 = T.alloc_local((1), dtype=accum_dtype)
+
+            # 16 stages
+            bar_00 = T.alloc_barrier(arrive_count=448)
+            bar_01 = T.alloc_barrier(arrive_count=384)
+            bar_02 = T.alloc_barrier(arrive_count=288)
+            bar_03 = T.alloc_barrier(arrive_count=256)
+            bar_04 = T.alloc_barrier(arrive_count=416)
+            bar_05 = T.alloc_barrier(arrive_count=288)
+            bar_06 = T.alloc_barrier(arrive_count=256)
+            bar_07 = T.alloc_barrier(arrive_count=256)
+            bar_08 = T.alloc_barrier(arrive_count=384)
+            bar_09 = T.alloc_barrier(arrive_count=256)
+            bar_10 = T.alloc_barrier(arrive_count=288)
+            bar_11 = T.alloc_barrier(arrive_count=256)
+            bar_12 = T.alloc_barrier(arrive_count=128)
+            bar_13 = T.alloc_barrier(arrive_count=256)
+            bar_14 = T.alloc_barrier(arrive_count=256)
+            bar_15 = T.alloc_barrier(arrive_count=256)
+
+            T.annotate_layout(
+                {
+                    do_shared: tilelang.layout.make_swizzled_layout(do_shared),
+                    q_shared: tilelang.layout.make_swizzled_layout(q_shared),
+                    k_shared: tilelang.layout.make_swizzled_layout(k_shared),
+                    v_shared: tilelang.layout.make_swizzled_layout(v_shared),
+                    a_shared: tilelang.layout.make_swizzled_layout(a_shared),
+                    h_shared: tilelang.layout.make_swizzled_layout(h_shared),
+                    dqkv_shared: tilelang.layout.make_swizzled_layout(dqkv_shared),
+                    tmp_shared_1_1: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_1_1
+                    ),
+                    tmp_shared_1_2: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_1_2
+                    ),
+                    tmp_shared_2_1: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_2_1
+                    ),
+                    tmp_shared_2_2: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_2_2
+                    ),
+                    tmp_shared_2_3: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_2_3
+                    ),
+                    tmp_shared_4_1: tilelang.layout.make_swizzled_layout(
+                        tmp_shared_4_1
+                    ),
+                }
+            )
+
+            # T.use_swizzle(10)
+
+            tx = T.get_thread_binding()
+
+            PRODUCER_NREG = 24
+            CONSUMER_K_NREG = 144
+            CONSUMER_A_NREG = 176
+            CONSUMER_S_NREG = 160
+
+            # Prefetch the last chunk of data
+            T.copy(
+                h[batch_idx, chunk_start_idx + num_iters - 1, bh, 0:DK, 0:DV], h_shared
+            )
+            for j_s, j_k in T.Parallel(block_S, DK):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    q_shared[j_s, j_k] = q[
+                        batch_idx,
+                        seq_start_idx + (num_iters - 1) * block_S + j_s,
+                        bhg,
+                        j_k,
+                    ]
+                else:
+                    q_shared[j_s, j_k] = 0
+            for j_s, j_k in T.Parallel(block_S, DK):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    k_shared[j_s, j_k] = k[
+                        batch_idx,
+                        seq_start_idx + (num_iters - 1) * block_S + j_s,
+                        bhg,
+                        j_k,
+                    ]
+                else:
+                    k_shared[j_s, j_k] = 0
+            for j_s, j_v in T.Parallel(block_S, DV):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    v_shared[j_s, j_v] = v[
+                        batch_idx,
+                        seq_start_idx + (num_iters - 1) * block_S + j_s,
+                        bh,
+                        j_v,
+                    ]
+                else:
+                    v_shared[j_s, j_v] = 0
+            for j_s, j_t in T.Parallel(block_S, block_S):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    a_shared[j_s, j_t] = a[
+                        batch_idx,
+                        seq_start_idx + (num_iters - 1) * block_S + j_s,
+                        bh,
+                        j_t,
+                    ]
+                else:
+                    a_shared[j_s, j_t] = 0
+            for j_s, j_v in T.Parallel(block_S, DV):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    do_shared[j_s, j_v] = do[
+                        batch_idx,
+                        seq_start_idx + (num_iters - 1) * block_S + j_s,
+                        bh,
+                        j_v,
+                    ]
+                else:
+                    do_shared[j_s, j_v] = 0
+            for j_s in T.Parallel(block_S):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    g_shared[j_s] = g[
+                        batch_idx, seq_start_idx + (num_iters - 1) * block_S + j_s, bh
+                    ]
+                else:
+                    g_shared[j_s] = g[batch_idx, seq_end_idx - 1, bh]
+            for j_s in T.Parallel(block_S):
+                if seq_start_idx + (num_iters - 1) * block_S + j_s < seq_end_idx:
+                    b_shared[j_s] = b[
+                        batch_idx, seq_start_idx + (num_iters - 1) * block_S + j_s, bh
+                    ]
+                else:
+                    b_shared[j_s] = 0
+
+            if tx < 128:
+                T.set_max_nreg(CONSUMER_S_NREG, 1)
+
+                if use_dht:
+                    T.copy(dht[bb, bh, 0:DK, 0:DV], dh_fragment)
+                else:
+                    T.clear(dh_fragment)
+                T.copy(dh_fragment, tmp_shared_4_1)
+
+                for i_s in T.serial(num_iters):
+                    T.barrier_arrive(bar_00)
+
+                    # 00
+                    T.barrier_wait(bar_00, (i_s + 0) % 2)
+                    for j_s in T.Parallel(block_S):
+                        g_exp_shared[j_s] = T.exp2(g_shared[j_s] * 1.442695)
+                        g_rev_exp_shared[j_s] = T.exp2(
+                            (g_shared[block_S - 1] - g_shared[j_s]) * 1.442695
+                        )
+                    T.barrier_arrive(bar_01)
+
+                    # 01, 02, 03
+                    T.barrier_wait(bar_01, (i_s + 0) % 2)
+                    g_last_local_3[0] = g_exp_shared[block_S - 1]
+                    # dS0 = g_last * dSt
+                    for j_k, j_v in T.Parallel(DK, DV):
+                        dh_fragment[j_k, j_v] *= g_last_local_3[0]
+                    T.barrier_arrive(bar_04)
+
+                    # 04, 05, 06, 07
+                    T.barrier_wait(bar_04, (i_s + 0) % 2)
+                    # dg_last += sum(dS0 * S0)
+                    T.clear(reduce_fragment)
+                    for j_k, j_v in T.Parallel(DK, DV):
+                        reduce_fragment[
+                            j_k % 64 // 16 * 32 + j_k % 8 * 4 + j_v % 8 // 2, j_v % 2
+                        ] += dh_fragment[j_k, j_v] * h_shared[j_k, j_v]
+                    T.barrier_arrive(bar_08)
+                    T.barrier_wait(bar_08, (i_s + 0) % 2)
+                    T.barrier_wait(bar_09, (i_s + 0) % 2)
+
+                    # 10
+                    T.barrier_wait(bar_10, (i_s + 0) % 2)
+                    T.reduce_sum(
+                        T.reshape(reduce_fragment, (128 * 2,)),
+                        dg_last_local_3,
+                        dim=0,
+                        clear=True,
+                    )
+                    dg_shared[block_S - 1] += dg_last_local_3[0]
+                    T.barrier_arrive(bar_11)
+
+                    # 11
+                    T.barrier_wait(bar_11, (i_s + 0) % 2)
+                    # dS0 += K^T @ dVg
+                    T.gemm(
+                        tmp_shared_2_2,
+                        tmp_shared_2_3,
+                        dh_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_12)
+                    T.barrier_wait(bar_12, (i_s + 0) % 2)
+
+                    # 13
+                    T.barrier_wait(bar_13, (i_s + 0) % 2)
+                    # dOg = s * g * dO
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        tmp_shared_2_3[j_s, j_v] = (
+                            scale * do_shared[j_s, j_v] * g_exp_shared[j_s]
+                        )
+                    T.barrier_arrive(bar_14)
+
+                    # 14
+                    T.barrier_wait(bar_14, (i_s + 0) % 2)
+                    # dS0 += Q^T @ dOg
+                    T.gemm(
+                        tmp_shared_2_1,
+                        tmp_shared_2_3,
+                        dh_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_15)
+
+                    # 15
+                    T.barrier_wait(bar_15, (i_s + 0) % 2)
+                    # S4[1] = dS0
+                    T.copy(dh_fragment, tmp_shared_4_1)
+
+                if use_dht:
+                    T.copy(dh_fragment, dh0[bb, bh, 0:DK, 0:DV])
+
+            elif tx < 256:
+                T.set_max_nreg(CONSUMER_K_NREG, 1)
+
+                for i_s in T.serial(num_iters):
+                    T.barrier_arrive(bar_00)
+
+                    # 16 == 00
+                    T.barrier_wait(bar_00, (i_s + 0) % 2)
+                    # S2[S] dK
+                    if i_s > 0:
+                        T.copy(dk_fragment, dqkv_shared)
+                    T.barrier_arrive(bar_01)
+
+                    # 01
+                    T.barrier_wait(bar_01, (i_s + 0) % 2)
+                    # dV' = K @ dSt
+                    T.gemm(k_shared, tmp_shared_4_1, dv_fragment, clear_accum=True)
+                    # dV' = g_last/g * dV'
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        dv_fragment[j_s, j_v] *= g_rev_exp_shared[j_s]
+                    T.barrier_arrive(bar_02)
+
+                    # 02
+                    T.barrier_wait(bar_02, (i_s + 0) % 2)
+                    # dV' += Pg^T @ dO
+                    T.gemm(
+                        tmp_shared_1_1,
+                        do_shared,
+                        dv_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_03)
+
+                    # 03
+                    T.barrier_wait(bar_03, (i_s + 0) % 2)
+                    # S2[1] dV'
+                    T.copy(dv_fragment, tmp_shared_2_1)
+                    T.barrier_arrive(bar_04)
+
+                    # 04
+                    T.barrier_wait(bar_04, (i_s + 0) % 2)
+                    # dV = Ag^T @ dV'
+                    T.gemm(
+                        tmp_shared_1_2,
+                        tmp_shared_2_1,
+                        dv_fragment,
+                        transpose_A=True,
+                        clear_accum=True,
+                    )
+                    # S2[S] dV
+                    T.copy(dv_fragment, dqkv_shared)
+                    T.barrier_arrive(bar_05)
+
+                    # 05
+                    T.barrier_wait(bar_05, (i_s + 0) % 2)
+                    # dVg = -g * dV
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        dv_fragment[j_s, j_v] = (
+                            -dv_fragment[j_s, j_v] * g_exp_shared[j_s]
+                        )
+                    # dg += sum(dVg * U)
+                    T.copy(tmp_shared_2_3, odot_fragment_1)
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        odot_fragment_1[j_s, j_v] *= dv_fragment[j_s, j_v]
+                    T.reduce_sum(odot_fragment_1, dg_fragment_1, dim=1, clear=True)
+                    T.copy(dg_fragment_1, dg_shared)
+                    # S2[3] dVg
+                    T.copy(dv_fragment, tmp_shared_2_3)
+                    T.barrier_arrive(bar_06)
+
+                    # 06
+                    T.barrier_wait(bar_06, (i_s + 0) % 2)
+                    # S2[2] K
+                    T.copy(k_shared, odot_fragment_1)
+                    T.copy(odot_fragment_1, tmp_shared_2_2)
+                    T.barrier_arrive(bar_07)
+
+                    # 07
+                    T.barrier_wait(bar_07, (i_s + 0) % 2)
+                    # dK = V' @ dSt^T
+                    T.gemm(
+                        tmp_shared_2_1,
+                        tmp_shared_4_1,
+                        dk_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    T.barrier_arrive(bar_08)
+
+                    # 08
+                    T.barrier_wait(bar_08, (i_s + 0) % 2)
+                    # dK = g_last/g * dK
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        dk_fragment[j_s, j_k] *= g_rev_exp_shared[j_s]
+                    # dg -= sum(K * dK)
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        odot_fragment_1[j_s, j_k] *= -dk_fragment[j_s, j_k]
+                    T.reduce_sum(odot_fragment_1, dg_fragment_1, dim=1, clear=True)
+                    for j_s in T.Parallel(block_S):
+                        dg_shared[j_s] += dg_fragment_1[j_s]
+                    # dg_last += sum(K * dK)
+                    T.reduce_sum(dg_fragment_1, dg_last_local_1, dim=0, clear=True)
+                    # Sg[S] dg
+                    dg_shared[block_S - 1] -= dg_last_local_1[0]
+                    T.barrier_arrive(bar_09)
+
+                    # 09
+                    T.barrier_wait(bar_09, (i_s + 0) % 2)
+                    # dK += dVg @ S0^T
+                    T.gemm(
+                        tmp_shared_2_3,
+                        h_shared,
+                        dk_fragment,
+                        transpose_B=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_10)
+                    T.barrier_wait(bar_10, (i_s + 0) % 2)
+
+                    # dK += dP^T @ Q. Both dP (tmp_shared_1_1) and Q
+                    # (tmp_shared_2_1) are ready at bar_10. Consume them here;
+                    # the A consumer overwrites tmp_shared_1_1 before the old
+                    # bar_12 read point on SM100.
+                    T.gemm(
+                        tmp_shared_1_1,
+                        tmp_shared_2_1,
+                        dk_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_13)
+                    T.barrier_wait(bar_13, (i_s + 0) % 2)
+
+                    # 15
+                    T.barrier_wait(bar_15, (i_s + 0) % 2)
+                    # dK += dAs @ K
+                    T.gemm(
+                        tmp_shared_1_2, tmp_shared_2_2, dk_fragment, clear_accum=False
+                    )
+
+                for j_s, j_k in T.Parallel(block_S, DK):
+                    if seq_start_idx + j_s < seq_end_idx:
+                        dk[batch_idx, seq_start_idx + j_s, bh, j_k] = dk_fragment[
+                            j_s, j_k
+                        ]
+
+            elif tx < 384:
+                T.set_max_nreg(CONSUMER_A_NREG, 1)
+
+                for i_s in T.serial(num_iters):
+                    T.barrier_arrive(bar_00)
+
+                    # 00
+                    T.barrier_wait(bar_00, (i_s + 0) % 2)
+                    # P = Q @ K^T
+                    T.gemm(
+                        q_shared,
+                        k_shared,
+                        p_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    T.barrier_arrive(bar_01)
+
+                    # 01
+                    T.barrier_wait(bar_01, (i_s + 0) % 2)
+                    # G = Lower(diag(g) @ I @ diag(1/g))
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        mask_fragment[j_s, j_t] = g_shared[j_s] - g_shared[j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        if j_s >= j_t:
+                            mask_fragment[j_s, j_t] = T.exp2(
+                                mask_fragment[j_s, j_t] * 1.442695
+                            )
+                        else:
+                            mask_fragment[j_s, j_t] = 0
+                    # Pg = s * P * G
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        p_fragment[j_s, j_t] *= mask_fragment[j_s, j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        p_fragment[j_s, j_t] *= scale
+                    # S1[1] Pg
+                    T.copy(p_fragment, tmp_shared_1_1)
+                    T.barrier_arrive(bar_02)
+
+                    # 02
+                    T.barrier_wait(bar_02, (i_s + 0) % 2)
+                    # Ab = Ar * b
+                    T.copy(a_shared, a_fragment)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= b_shared[j_t]
+                    # Ag = G * Ab
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= mask_fragment[j_s, j_t]
+                    # S1[2] Ag
+                    T.copy(a_fragment, tmp_shared_1_2)
+                    T.barrier_arrive(bar_03)
+
+                    # 03
+                    T.barrier_wait(bar_03, (i_s + 0) % 2)
+                    # U = K @ S0
+                    T.gemm(k_shared, h_shared, u_fragment, clear_accum=True)
+                    T.barrier_arrive(bar_04)
+
+                    # 04
+                    T.barrier_wait(bar_04, (i_s + 0) % 2)
+                    # S2[3] U
+                    T.copy(u_fragment, tmp_shared_2_3)
+                    # W = V - g * U
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        u_fragment[j_s, j_v] *= -g_exp_shared[j_s]
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        u_fragment[j_s, j_v] += v_shared[j_s, j_v]
+                    # S2[2] W
+                    T.copy(u_fragment, tmp_shared_2_2)
+                    T.barrier_arrive(bar_05)
+
+                    # 05
+                    T.barrier_wait(bar_05, (i_s + 0) % 2)
+                    # dAg = dV' @ W^T
+                    T.gemm(
+                        tmp_shared_2_1,
+                        tmp_shared_2_2,
+                        da_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    # V' = Ag @ W
+                    T.gemm(tmp_shared_1_2, tmp_shared_2_2, u_fragment, clear_accum=True)
+                    # S2[1] V'
+                    T.copy(u_fragment, tmp_shared_2_1)
+                    T.barrier_arrive(bar_06)
+
+                    # 06
+                    T.barrier_wait(bar_06, (i_s + 0) % 2)
+                    # dPg = dO @ V'^T
+                    T.gemm(
+                        do_shared,
+                        tmp_shared_2_1,
+                        dp_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    T.barrier_arrive(bar_07)
+
+                    # 07
+                    T.barrier_wait(bar_07, (i_s + 0) % 2)
+                    # dAb = G * dAg
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        da_fragment[j_s, j_t] *= mask_fragment[j_s, j_t]
+                    # dg += sum((dPg * P) - (dPg * P)^T). Compute the
+                    # antisymmetric row sum as row_sum(M) - col_sum(M) in fp32;
+                    # the original bf16 shared matrix round-trip adds a small
+                    # raw-dg bias on SM100 that later reductions amplify.
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        p_fragment[j_s, j_t] *= dp_fragment[j_s, j_t]
+                    T.reduce_sum(p_fragment, dg_fragment_2, dim=1, clear=True)
+                    T.copy(dg_fragment_2, dg_vec_shared)
+                    T.reduce_sum(p_fragment, dg_col_fragment_2, dim=0, clear=True)
+                    T.copy(dg_col_fragment_2, dg_col_vec_shared)
+                    for j_s in T.Parallel(block_S):
+                        dg_fragment_2[j_s] = dg_vec_shared[j_s] - dg_col_vec_shared[j_s]
+                    # dP = s * G * dPg
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        dp_fragment[j_s, j_t] *= mask_fragment[j_s, j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        dp_fragment[j_s, j_t] *= scale
+                    # S1[1] dP
+                    T.copy(dp_fragment, tmp_shared_1_1)
+                    T.barrier_arrive(bar_08)
+
+                    # 08
+                    T.barrier_wait(bar_08, (i_s + 0) % 2)
+                    # dQ = dO @ S0^T
+                    T.gemm(
+                        do_shared,
+                        h_shared,
+                        dq_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    T.barrier_arrive(bar_09)
+
+                    # 09
+                    T.barrier_wait(bar_09, (i_s + 0) % 2)
+                    # dQ = s * g * dQ
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        dq_fragment[j_s, j_k] *= g_exp_shared[j_s]
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        dq_fragment[j_s, j_k] *= scale
+                    # S2[1] Q
+                    T.copy(q_shared, odot_fragment_2)
+                    # dg += sum(Q * dQ)
+                    T.copy(odot_fragment_2, tmp_shared_2_1)
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        odot_fragment_2[j_s, j_k] *= dq_fragment[j_s, j_k]
+                    T.reduce_sum(odot_fragment_2, dg_fragment_2, dim=1, clear=False)
+                    T.barrier_arrive(bar_10)
+
+                    # 10
+                    T.barrier_wait(bar_10, (i_s + 0) % 2)
+                    # dQ += dP @ K
+                    T.gemm(
+                        tmp_shared_1_1, tmp_shared_2_2, dq_fragment, clear_accum=False
+                    )
+                    # S2[S] dQ
+                    T.copy(dq_fragment, dqkv_shared)
+                    T.barrier_arrive(bar_11)
+
+                    # 11, 12
+                    T.barrier_wait(bar_11, (i_s + 0) % 2)
+                    # dAb * Ar
+                    T.copy(a_shared, a_fragment)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= da_fragment[j_s, j_t]
+                    T.copy(a_fragment, tmp_shared_1_1)
+                    # dAb * Ab [ = G * dAg * Ab ]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= b_shared[j_t]
+                    # dg += sum((dAb * Ab) - (dAb * Ab)^T)
+                    T.reduce_sum(a_fragment, db_fragment, dim=1, clear=True)
+                    T.copy(db_fragment, dg_vec_shared)
+                    T.reduce_sum(a_fragment, dg_col_fragment_2, dim=0, clear=True)
+                    T.copy(dg_col_fragment_2, dg_col_vec_shared)
+                    for j_s in T.Parallel(block_S):
+                        dg_fragment_2[j_s] += (
+                            dg_vec_shared[j_s] - dg_col_vec_shared[j_s]
+                        )
+                    # Sg[S] dg
+                    for j_s in T.Parallel(block_S):
+                        dg_shared[j_s] += dg_fragment_2[j_s]
+                    # db = sum((dAb * Ar)^T)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] = tmp_shared_1_1[j_t, j_s]
+                    T.reduce_sum(a_fragment, db_fragment, dim=1, clear=True)
+                    # dAr = dAb * b
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        da_fragment[j_s, j_t] *= b_shared[j_t]
+                    # S1[2] dAr
+                    T.copy(da_fragment, tmp_shared_1_2)
+                    T.barrier_arrive(bar_13)
+
+                    # 13
+                    T.barrier_wait(bar_13, (i_s + 0) % 2)
+                    # dA = -Ar^T @ dAr @ Ar^T
+                    T.gemm(
+                        a_shared,
+                        tmp_shared_1_2,
+                        da_fragment,
+                        transpose_A=True,
+                        clear_accum=True,
+                    )
+                    T.copy(da_fragment, tmp_shared_1_2)
+                    T.gemm(
+                        tmp_shared_1_2,
+                        a_shared,
+                        da_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    # At = K @ K^T
+                    T.gemm(
+                        tmp_shared_2_2,
+                        tmp_shared_2_2,
+                        a_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+                    T.barrier_arrive(bar_14)
+
+                    # 14
+                    T.barrier_wait(bar_14, (i_s + 0) % 2)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        if j_s <= j_t:
+                            da_fragment[j_s, j_t] = 0
+                        else:
+                            da_fragment[j_s, j_t] = -da_fragment[j_s, j_t]
+                    # db += sum(dA * At)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= da_fragment[j_s, j_t]
+                    T.reduce_sum(a_fragment, db_fragment, dim=1, clear=False)
+                    T.copy(db_fragment, db_shared)
+                    # dAt = b * dA
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        da_fragment[j_s, j_t] *= b_shared[j_s]
+                    # dAs = dAt + dAt^T
+                    T.copy(da_fragment, tmp_shared_1_2)
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        da_fragment[j_s, j_t] += tmp_shared_1_2[j_t, j_s]
+                    # S1[1] dAs
+                    T.copy(da_fragment, tmp_shared_1_2)
+                    T.barrier_arrive(bar_15)
+                    T.barrier_wait(bar_15, (i_s + 0) % 2)
+
+            else:
+                T.set_max_nreg(PRODUCER_NREG, 0)
+
+                if tx < 384 + 32:
+                    for i_s in T.serial(num_iters - 1):
+                        chunk_idx = num_iters - i_s - 2
+                        left = seq_start_idx + chunk_idx * block_S
+                        right = left + block_S
+
+                        T.barrier_arrive(bar_00)
+                        T.barrier_wait(bar_00, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_03, (i_s + 0) % 2)
+                        for j_s in T.Parallel(block_S):
+                            g_shared[j_s] = g[batch_idx, left + j_s, bh]
+
+                        T.barrier_wait(bar_05, (i_s + 0) % 2)
+                        T.copy(v[batch_idx, left:right, bh, 0:DV], v_shared)
+
+                        T.barrier_wait(bar_07, (i_s + 0) % 2)
+                        T.copy(k[batch_idx, left:right, bhg, 0:DK], k_shared)
+
+                        T.barrier_wait(bar_10, (i_s + 0) % 2)
+                        T.copy(q[batch_idx, left:right, bhg, 0:DK], q_shared)
+
+                    if num_iters > 0:
+                        T.barrier_arrive(bar_00)
+
+                elif tx < 384 + 64:
+                    for i_s in T.serial(num_iters):
+                        left = seq_start_idx + (num_iters - i_s - 1) * block_S
+                        right = left + block_S
+
+                        T.barrier_arrive(bar_00)
+                        T.barrier_wait(bar_00, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_01, (i_s + 0) % 2)
+                        if i_s == 1:
+                            for j_s, j_k in T.Parallel(block_S, DK):
+                                if left + block_S + j_s < seq_end_idx:
+                                    dk[batch_idx, left + block_S + j_s, bh, j_k] = (
+                                        dqkv_shared[j_s, j_k]
+                                    )
+                        elif i_s > 1:
+                            T.copy(
+                                dqkv_shared,
+                                dk[
+                                    batch_idx,
+                                    left + block_S : right + block_S,
+                                    bh,
+                                    0:DK,
+                                ],
+                            )
+                        T.barrier_arrive(bar_04)
+                        T.barrier_wait(bar_04, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_05, (i_s + 0) % 2)
+                        if i_s == 0:
+                            for j_s, j_v in T.Parallel(block_S, DV):
+                                if left + j_s < seq_end_idx:
+                                    dv[batch_idx, left + j_s, bh, j_v] = dqkv_shared[
+                                        j_s, j_v
+                                    ]
+                        else:
+                            T.copy(dqkv_shared, dv[batch_idx, left:right, bh, 0:DV])
+                        T.barrier_arrive(bar_10)
+                        T.barrier_wait(bar_10, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_11, (i_s + 0) % 2)
+                        if i_s == 0:
+                            for j_s, j_k in T.Parallel(block_S, DK):
+                                if left + j_s < seq_end_idx:
+                                    dq[batch_idx, left + j_s, bh, j_k] = dqkv_shared[
+                                        j_s, j_k
+                                    ]
+                        else:
+                            T.copy(dqkv_shared, dq[batch_idx, left:right, bh, 0:DK])
+
+                elif tx < 384 + 96:
+                    for i_s in T.serial(num_iters - 1):
+                        chunk_idx = num_iters - i_s - 2
+                        left = seq_start_idx + chunk_idx * block_S
+                        right = left + block_S
+
+                        T.barrier_arrive(bar_02)
+                        T.barrier_wait(bar_02, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_10, (i_s + 0) % 2)
+                        T.copy(
+                            h[batch_idx, chunk_start_idx + chunk_idx, bh, 0:DK, 0:DV],
+                            h_shared,
+                        )
+
+                        T.barrier_wait(bar_14, (i_s + 0) % 2)
+                        T.copy(a[batch_idx, left:right, bh, 0:block_S], a_shared)
+
+                        T.copy(do[batch_idx, left:right, bh, 0:DV], do_shared)
+
+                        T.barrier_wait(bar_15, (i_s + 0) % 2)
+                        for j_s in T.Parallel(block_S):
+                            b_shared[j_s] = b[batch_idx, left + j_s, bh]
+
+                    if num_iters > 0:
+                        T.barrier_wait(bar_00, (num_iters - 1) % 2)
+                        T.barrier_arrive(bar_02)
+
+                else:
+                    for i_s in T.serial(num_iters):
+                        left = seq_start_idx + (num_iters - i_s - 1) * block_S
+
+                        T.barrier_arrive(bar_05)
+                        T.barrier_wait(bar_05, (i_s + 0) % 2)
+
+                        T.barrier_wait(bar_15, (i_s + 0) % 2)
+
+                        if i_s == 0:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    dg[batch_idx, left + j_s, bh] = dg_shared[j_s]
+                            if (seq_end_idx - seq_start_idx) % block_S > 0:
+                                dg[batch_idx, seq_end_idx - 1, bh] += dg_shared[
+                                    block_S - 1
+                                ]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                dg[batch_idx, left + j_s, bh] = dg_shared[j_s]
+
+                        if i_s == 0:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    db[batch_idx, left + j_s, bh] = db_shared[j_s]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                db[batch_idx, left + j_s, bh] = db_shared[j_s]
+
+    return tilelang_fused_chunk_gdr_bwd_kernel
+
+
+def fused_gdr_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    g: torch.Tensor,
+    b: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    h: torch.Tensor,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+):
+    batch_size, num_tokens, Hg, K = k.shape
+    _, _, H, V = v.shape
+    scale = scale or K ** (-0.5)
+    assert K == V == 128
+    assert chunk_size == 64
+
+    if cu_seqlens is None:
+        real_batch_size = batch_size
+        cu_seqlens = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
+        chunk_offsets = torch.empty(
+            (batch_size + 1), dtype=torch.int32, device=k.device
+        )
+        is_varlen = False
+    else:
+        real_batch_size = len(cu_seqlens) - 1
+        chunk_offsets, _ = prepare_chunk_offsets(cu_seqlens, chunk_size)
+        chunk_offsets = chunk_offsets.to(cu_seqlens.dtype)
+        is_varlen = True
+
+    use_dht = dht is not None
+    if dht is None:
+        dht = torch.empty(
+            (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
+        )
+    dq = torch.empty_like(v)
+    dk = torch.empty_like(v)
+    dv = torch.empty_like(v)
+    dg = torch.empty_like(g)
+    db = torch.empty_like(b)
+    dh0 = torch.empty_like(dht)
+
+    tilelang_fused_chunk_gdr_bwd_kernel = tilelang_fused_chunk_gdr_bwd(
+        H,
+        Hg,
+        K,
+        V,
+        chunk_size,
+        scale,
+        qkva_dtype=q.dtype,
+        g_dtype=g.dtype,
+        b_dtype=b.dtype,
+        h_dtype=h.dtype,
+        o_dtype=do.dtype,
+        seqlen_dtype=cu_seqlens.dtype,
+        accum_dtype="float32",
+        is_varlen=is_varlen,
+        use_dht=use_dht,
+    )
+    tilelang_fused_chunk_gdr_bwd_kernel(
+        do,
+        dht,
+        q,
+        k,
+        v,
+        a,
+        g,
+        b,
+        h,
+        cu_seqlens,
+        chunk_offsets,
+        dq,
+        dk,
+        dv,
+        dg,
+        db,
+        dh0,
+    )
+
+    if not use_dht:
+        dh0 = None
+
+    return dq, dk, dv, dg, db, dh0

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_fwd.py
@@ -1,0 +1,658 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import torch
+import tilelang
+import tilelang.language as T
+
+from flash_qla.utils import prepare_chunk_offsets
+
+
+MULTI_PROCESSOR_COUNT = torch.cuda.get_device_properties().multi_processor_count
+TARGET_NUM_CTAS = int(MULTI_PROCESSOR_COUNT * 0.7)
+
+
+@tilelang.jit(
+    # out_idx=[-3, -2, -1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        # tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    },
+)
+def tilelang_fused_chunk_gdr_fwd(
+    H,
+    Hg,
+    DK,
+    DV,
+    chunk_size,
+    scale,
+    accum_dtype,
+    qkva_dtype,
+    g_dtype,
+    b_dtype,
+    h0_dtype,
+    ht_dtype,
+    h_dtype,
+    o_dtype,
+    seqlen_dtype,
+    use_initial_state,
+    store_final_state,
+    store_h,
+    store_o,
+    is_varlen,
+    is_cp,
+    block_DV=128,
+):
+    batch_size = T.dynamic("batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_chunks = T.dynamic("num_chunks")
+    raw_batch_size = T.dynamic("raw_batch_size")
+    block_S = chunk_size
+
+    if is_varlen:
+        q_shape = (1, num_tokens, Hg, DK)
+        k_shape = (1, num_tokens, Hg, DK)
+        v_shape = (1, num_tokens, H, DV)
+        o_shape = (1, num_tokens, H, DV)
+        a_shape = (1, num_tokens, H, chunk_size)
+        g_shape = (1, num_tokens, H)
+        b_shape = (1, num_tokens, H)
+        h_shape = (1, num_chunks, H, DK, DV)
+    else:
+        q_shape = (batch_size, num_tokens, Hg, DK)
+        k_shape = (batch_size, num_tokens, Hg, DK)
+        v_shape = (batch_size, num_tokens, H, DV)
+        o_shape = (batch_size, num_tokens, H, DV)
+        a_shape = (batch_size, num_tokens, H, chunk_size)
+        g_shape = (batch_size, num_tokens, H)
+        b_shape = (batch_size, num_tokens, H)
+        h_shape = (batch_size, num_chunks, H, DK, DV)
+    h0_shape = (batch_size, H, DK, DV)
+    ht_shape = (raw_batch_size, H, DK, DV)
+
+    @T.prim_func
+    def tilelang_fused_chunk_gdr_fwd_kernel(
+        q: T.Tensor(q_shape, dtype=qkva_dtype),
+        k: T.Tensor(k_shape, dtype=qkva_dtype),
+        v: T.Tensor(v_shape, dtype=qkva_dtype),
+        a: T.Tensor(a_shape, dtype=qkva_dtype),
+        g: T.Tensor(g_shape, dtype=g_dtype),
+        b: T.Tensor(b_shape, dtype=b_dtype),
+        h0: T.Tensor(h0_shape, dtype=h0_dtype),
+        cu_seqlens: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        chunk_offsets: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        cp_seq_map: T.Tensor([batch_size], dtype=seqlen_dtype),
+        raw_cu_seqlens: T.Tensor([raw_batch_size + 1], dtype=seqlen_dtype),
+        o: T.Tensor(o_shape, dtype=o_dtype),
+        h: T.Tensor(h_shape, dtype=h_dtype),
+        ht: T.Tensor(ht_shape, dtype=ht_dtype),
+    ):
+        with T.Kernel(T.ceildiv(DV, block_DV) * batch_size * H, threads=512) as (bbhv,):
+            bbh, bv = bbhv // T.ceildiv(DV, block_DV), bbhv % T.ceildiv(DV, block_DV)
+            bb, bh = bbh // H, bbh % H
+            bhg = bh // (H // Hg)
+
+            batch_idx = T.alloc_var("int32")
+            seq_start_idx = T.alloc_var("int32")
+            seq_end_idx = T.alloc_var("int32")
+            seq_split_idx = T.alloc_var("int32")
+            chunk_start_idx = T.alloc_var("int32")
+            chunk_split_idx = T.alloc_var("int32")
+
+            batch_idx = 0 if is_varlen else bb
+            seq_start_idx = cu_seqlens[bb] if is_varlen else 0
+            seq_end_idx = cu_seqlens[bb + 1] if is_varlen else num_tokens
+            chunk_start_idx = chunk_offsets[bb] if is_varlen else 0
+
+            raw_batch_idx = T.alloc_var("int32")
+            raw_seq_end_idx = T.alloc_var("int32")
+            need_store_final_state = T.alloc_var("bool")
+            raw_batch_idx = cp_seq_map[bb] if is_cp else bb
+            raw_seq_end_idx = (
+                raw_cu_seqlens[raw_batch_idx + 1] if is_cp else seq_end_idx
+            )
+            need_store_final_state = store_final_state & (
+                raw_seq_end_idx == seq_end_idx
+            )
+
+            num_iters = T.alloc_var("int32")
+            num_unmasked_iters = T.alloc_var("int32")
+            num_iters = T.ceildiv(seq_end_idx - seq_start_idx, block_S)
+            num_unmasked_iters = (seq_end_idx - seq_start_idx) // block_S
+
+            q_shared = T.alloc_shared((2, block_S, DK), dtype=qkva_dtype)
+            k_shared = T.alloc_shared((2, block_S, DK), dtype=qkva_dtype)
+            v_shared = T.alloc_shared((2, block_S, block_DV), dtype=qkva_dtype)
+            a_shared = T.alloc_shared((2, block_S, block_S), dtype=qkva_dtype)
+            g_shared = T.alloc_shared((2, block_S), dtype=accum_dtype, scope="shared")
+            b_shared = T.alloc_shared((2, block_S), dtype=accum_dtype, scope="shared")
+
+            o_shared = T.alloc_shared((block_S, block_DV), dtype=o_dtype)
+            h_shared = T.alloc_shared((DK, block_DV), dtype=qkva_dtype)
+            vd_shared = T.alloc_shared((block_S, block_DV), dtype=qkva_dtype)
+            vn_shared = T.alloc_shared((block_S, block_DV), dtype=qkva_dtype)
+            p_shared = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
+            g_exp_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+            g_rev_exp_shared = T.alloc_shared(
+                (block_S), dtype=accum_dtype, scope="shared"
+            )
+
+            h_fragment = T.alloc_fragment((DK, block_DV), dtype=accum_dtype)
+            o_fragment = T.alloc_fragment((block_S, block_DV), dtype=accum_dtype)
+            v_fragment = T.alloc_fragment((block_S, block_DV), dtype=accum_dtype)
+            u_fragment = T.alloc_fragment((block_S, block_DV), dtype=accum_dtype)
+            p_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            a_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            g_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+            g_last_local = T.alloc_local((1), dtype=accum_dtype)
+
+            data_is_ready = T.alloc_barrier(arrive_count=[96] * 2)
+            data_is_free = T.alloc_barrier(arrive_count=[384] * 2)
+
+            bar_o = T.alloc_barrier(arrive_count=128)
+            bar_0 = T.alloc_barrier(arrive_count=416)
+            bar_1 = T.alloc_barrier(arrive_count=256)
+            _bar_2 = T.alloc_barrier(arrive_count=128)
+            bar_3 = T.alloc_barrier(arrive_count=128)
+            bar_4 = T.alloc_barrier(arrive_count=128)
+            bar_5 = T.alloc_barrier(arrive_count=416)
+
+            T.use_swizzle(10)
+
+            tx = T.get_thread_binding()
+
+            PRODUCER_NREG = 32
+            CONSUMER_V_NREG = 128
+            CONSUMER_S_NREG = 160
+            CONSUMER_O_NREG = 128
+
+            if tx < 128:
+                T.set_max_nreg(CONSUMER_S_NREG, 1)
+
+                # Initialize S
+                if use_initial_state:
+                    T.copy(
+                        h0[bb, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV],
+                        h_fragment,
+                    )
+                else:
+                    T.clear(h_fragment)
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE 0]
+                    T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE 0] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # S4[S] S
+                    T.copy(h_fragment, h_shared)
+                    T.barrier_arrive(bar_1)
+
+                    # [STAGE 0] 2, 3, 4
+                    T.barrier_wait(bar_1, i_s % 2)
+                    # S = g_last * S
+                    g_last_local[0] = g_exp_shared[block_S - 1]
+                    for j_k, j_v in T.Parallel(DK, block_DV):
+                        h_fragment[j_k, j_v] *= g_last_local[0]
+                    T.barrier_arrive(bar_5)
+
+                    # [STAGE 0] 5
+                    T.barrier_wait(bar_5, i_s % 2)
+                    # S += K^T @ V'
+                    T.gemm(
+                        k_shared[i_s % 2, :, :],
+                        vn_shared,
+                        h_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+
+                    T.barrier_arrive(data_is_free[i_s % 2])
+
+                # Store final S
+                if need_store_final_state:
+                    T.copy(
+                        h_fragment,
+                        ht[
+                            raw_batch_idx, bh, 0:DK, bv * block_DV : (bv + 1) * block_DV
+                        ],
+                    )
+
+            elif tx < 256:
+                T.set_max_nreg(CONSUMER_V_NREG, 1)
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE 0]
+                    T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE 0] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # Precompute g, g_last/g
+                    for j_s in T.Parallel(block_S):
+                        g_exp_shared[j_s] = T.exp2(g_shared[i_s % 2, j_s] * 1.442695)
+                    for j_s in T.Parallel(block_S):
+                        g_rev_exp_shared[j_s] = T.if_then_else(
+                            seq_start_idx + i_s * block_S + j_s < seq_end_idx,
+                            T.exp2(
+                                (
+                                    g_shared[i_s % 2, block_S - 1]
+                                    - g_shared[i_s % 2, j_s]
+                                )
+                                * 1.442695
+                            ),
+                            0.0,
+                        )
+                    T.barrier_arrive(bar_1)
+
+                    # [STAGE 0] 1
+                    T.barrier_wait(bar_1, i_s % 2)
+                    # U = K @ S
+                    T.gemm(
+                        k_shared[i_s % 2, :, :], h_shared, u_fragment, clear_accum=True
+                    )
+
+                    # [STAGE 0] 2
+                    # W = V - g * U
+                    for j_s, j_v in T.Parallel(block_S, block_DV):
+                        u_fragment[j_s, j_v] *= -g_exp_shared[j_s]
+                    for j_s, j_v in T.Parallel(block_S, block_DV):
+                        u_fragment[j_s, j_v] += v_shared[i_s % 2, j_s, j_v]
+                    # S2[V] W
+                    for j_s, j_v in T.Parallel(block_S, block_DV):
+                        v_shared[i_s % 2, j_s, j_v] = u_fragment[j_s, j_v]
+
+                    # [STAGE 0] 3
+                    T.barrier_wait(bar_3, i_s % 2)
+                    # Vd = Ag @ W
+                    T.gemm(
+                        a_shared[i_s % 2, :, :],
+                        v_shared[i_s % 2, :, :],
+                        v_fragment,
+                        clear_accum=True,
+                    )
+                    # S2[2] Vd
+                    T.copy(v_fragment, vd_shared)
+                    T.barrier_arrive(bar_4)
+
+                    # [STAGE 0] 4
+                    # V' = g_last/g Vd
+                    for j_s, j_v in T.Parallel(block_S, block_DV):
+                        v_fragment[j_s, j_v] *= g_rev_exp_shared[j_s]
+                    # S2[1] V'
+                    T.copy(v_fragment, vn_shared)
+                    T.barrier_arrive(bar_5)
+
+                    T.barrier_wait(bar_5, i_s % 2)
+
+                    T.barrier_arrive(data_is_free[i_s % 2])
+
+            elif tx < 384:
+                T.set_max_nreg(CONSUMER_O_NREG, 1)
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE 0]
+                    T.barrier_wait(data_is_ready[i_s % 2], (i_s // 2 + 0) % 2)
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE 0] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # P = Q K^T
+                    T.gemm(
+                        q_shared[i_s % 2, :, :],
+                        k_shared[i_s % 2, :, :],
+                        p_fragment,
+                        transpose_B=True,
+                        clear_accum=True,
+                    )
+
+                    # [STAGE 0] 1
+                    # G = Lower(diag(g) @ I @ diag(1/g))
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        g_fragment[j_s, j_t] = (
+                            g_shared[i_s % 2, j_s] - g_shared[i_s % 2, j_t]
+                        )
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        if j_s >= j_t:
+                            g_fragment[j_s, j_t] = T.exp2(
+                                g_fragment[j_s, j_t] * 1.442695
+                            )
+                        else:
+                            g_fragment[j_s, j_t] = 0
+                    # Ag = G * Ar * b
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] = a_shared[i_s % 2, j_s, j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= g_fragment[j_s, j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_fragment[j_s, j_t] *= b_shared[i_s % 2, j_t]
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        a_shared[i_s % 2, j_s, j_t] = a_fragment[j_s, j_t]
+
+                    # [STAGE 0] 2
+                    T.barrier_wait(bar_1, i_s % 2)
+                    # O = Q @ S
+                    T.gemm(
+                        q_shared[i_s % 2, :, :], h_shared, o_fragment, clear_accum=True
+                    )
+
+                    # [STAGE 0] 3
+                    # Pg = s * G * P
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        p_fragment[j_s, j_t] *= scale * g_fragment[j_s, j_t]
+                    # S1[1] Pg
+                    T.copy(p_fragment, p_shared)
+                    T.barrier_arrive(bar_3)
+                    # O = s * g * O
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        o_fragment[j_s, j_k] *= scale * g_exp_shared[j_s]
+
+                    # [STAGE 0] 4
+                    T.barrier_wait(bar_4, i_s % 2)
+                    # O += Pg @ Vd
+                    T.gemm(p_shared, vd_shared, o_fragment, clear_accum=False)
+                    T.barrier_arrive(bar_5)
+
+                    # [STAGE 0] 5
+                    T.barrier_wait(bar_5, i_s % 2)
+                    # S2[S] O
+                    T.copy(o_fragment, o_shared)
+
+                    T.barrier_arrive(data_is_free[i_s % 2])
+
+                T.barrier_arrive(bar_o)
+
+            else:
+                T.set_max_nreg(PRODUCER_NREG, 0)
+
+                if tx < 384 + 32:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(data_is_free[i_s % 2], (i_s // 2 + 1) % 2)
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load Q
+                        T.copy(
+                            q[batch_idx, left:right, bhg, 0:DK], q_shared[i_s % 2, :, :]
+                        )
+                        # Load K
+                        T.copy(
+                            k[batch_idx, left:right, bhg, 0:DK], k_shared[i_s % 2, :, :]
+                        )
+
+                        T.barrier_arrive(data_is_ready[i_s % 2])
+
+                elif tx < 384 + 64:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(data_is_free[i_s % 2], (i_s // 2 + 1) % 2)
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load V
+                        T.copy(
+                            v[
+                                batch_idx,
+                                left:right,
+                                bh,
+                                bv * block_DV : (bv + 1) * block_DV,
+                            ],
+                            v_shared[i_s % 2, :, :],
+                        )
+                        # Load beta
+                        if right <= seq_end_idx:
+                            for j_s in T.Parallel(block_S):
+                                b_shared[i_s % 2, j_s] = b[batch_idx, left + j_s, bh]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    b_shared[i_s % 2, j_s] = b[
+                                        batch_idx, left + j_s, bh
+                                    ]
+                                else:
+                                    b_shared[i_s % 2, j_s] = 0
+
+                        T.barrier_arrive(data_is_ready[i_s % 2])
+
+                elif tx < 384 + 96:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(data_is_free[i_s % 2], (i_s // 2 + 1) % 2)
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load A
+                        T.copy(
+                            a[batch_idx, left:right, bh, 0:block_S],
+                            a_shared[i_s % 2, :, :],
+                        )
+                        # Load gamma
+                        if right <= seq_end_idx:
+                            for j_s in T.Parallel(block_S):
+                                g_shared[i_s % 2, j_s] = g[batch_idx, left + j_s, bh]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    g_shared[i_s % 2, j_s] = g[
+                                        batch_idx, left + j_s, bh
+                                    ]
+                                else:
+                                    g_shared[i_s % 2, j_s] = g[
+                                        batch_idx, seq_end_idx - 1, bh
+                                    ]
+
+                        T.barrier_arrive(data_is_ready[i_s % 2])
+
+                else:
+                    for i_s in T.serial(num_unmasked_iters):
+                        right = seq_start_idx + i_s * block_S
+                        left = right - block_S
+
+                        T.barrier_arrive(bar_0)
+
+                        T.barrier_wait(bar_0, i_s % 2)
+                        # Store O
+                        if i_s > 0 and store_o:
+                            T.copy(
+                                o_shared,
+                                o[
+                                    batch_idx,
+                                    left:right,
+                                    bh,
+                                    bv * block_DV : (bv + 1) * block_DV,
+                                ],
+                            )
+                        T.barrier_arrive(bar_5)
+
+                        T.barrier_wait(bar_1, i_s % 2)
+                        # Store S
+                        if store_h:
+                            T.copy(
+                                h_shared,
+                                h[
+                                    batch_idx,
+                                    chunk_start_idx + i_s,
+                                    bh,
+                                    0:DK,
+                                    bv * block_DV : (bv + 1) * block_DV,
+                                ],
+                            )
+
+                    if num_unmasked_iters < num_iters:
+                        seq_split_idx = seq_start_idx + num_unmasked_iters * block_S
+                        chunk_split_idx = chunk_start_idx + num_unmasked_iters
+
+                        T.barrier_arrive(bar_0)
+
+                        T.barrier_wait(bar_0, num_unmasked_iters % 2)
+                        # Store O
+                        if num_unmasked_iters > 0 and store_o:
+                            T.copy(
+                                o_shared,
+                                o[
+                                    batch_idx,
+                                    seq_split_idx - block_S : seq_split_idx,
+                                    bh,
+                                    bv * block_DV : (bv + 1) * block_DV,
+                                ],
+                            )
+                        T.barrier_arrive(bar_5)
+
+                        T.barrier_wait(bar_1, num_unmasked_iters % 2)
+                        # Store S
+                        if store_h:
+                            T.copy(
+                                h_shared,
+                                h[
+                                    batch_idx,
+                                    chunk_split_idx,
+                                    bh,
+                                    0:DK,
+                                    bv * block_DV : (bv + 1) * block_DV,
+                                ],
+                            )
+
+                    seq_split_idx = seq_start_idx + (num_iters - 1) * block_S
+
+                    # Store O
+                    T.barrier_wait(bar_o, 0)
+                    if store_o:
+                        for j_s, j_v in T.Parallel(block_S, block_DV):
+                            with T.If(seq_split_idx + j_s < seq_end_idx):
+                                with T.Then():
+                                    o[
+                                        batch_idx,
+                                        seq_split_idx + j_s,
+                                        bh,
+                                        bv * block_DV + j_v,
+                                    ] = o_shared[j_s, j_v]
+
+    return tilelang_fused_chunk_gdr_fwd_kernel
+
+
+def fused_gdr_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    g: torch.Tensor,
+    b: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = True,
+    output_h: bool = False,
+    output_o: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_seq_map: torch.LongTensor | None = None,
+    raw_cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+):
+    batch_size, num_tokens, Hg, K = k.shape
+    _, _, H, V = v.shape
+    scale = scale or K ** (-0.5)
+    assert K == V == 128
+    assert chunk_size == 64
+
+    if cu_seqlens is None:
+        real_batch_size = batch_size
+        num_chunks = tilelang.cdiv(num_tokens, chunk_size) if output_h else 0
+        cu_seqlens = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
+        chunk_offsets = torch.empty(
+            (batch_size + 1), dtype=torch.int32, device=k.device
+        )
+        seqlen_dtype = torch.int32
+        is_varlen = False
+    else:
+        real_batch_size = len(cu_seqlens) - 1
+        chunk_offsets, num_chunks = prepare_chunk_offsets(cu_seqlens, chunk_size)
+        chunk_offsets = chunk_offsets.to(cu_seqlens.dtype)
+        num_chunks = num_chunks if output_h else 0
+        seqlen_dtype = cu_seqlens.dtype
+        is_varlen = True
+
+    if cp_seq_map is None:
+        cp_seq_map = torch.empty(
+            (real_batch_size,), dtype=seqlen_dtype, device=k.device
+        )
+        is_cp = False
+    else:
+        is_cp = True
+
+    use_initial_state = initial_state is not None
+    if initial_state is None:
+        initial_state = torch.empty(
+            (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
+        )
+    h = torch.empty((batch_size, num_chunks, H, K, V), dtype=k.dtype, device=k.device)
+    if raw_cu_seqlens is None:
+        raw_cu_seqlens = torch.empty(
+            (real_batch_size + 1,), dtype=seqlen_dtype, device=k.device
+        )
+        final_state = torch.empty(
+            (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
+        )
+    else:
+        final_state = torch.empty(
+            (raw_cu_seqlens.shape[0] - 1, H, K, V), dtype=torch.float32, device=k.device
+        )
+    o = torch.empty_like(v)
+
+    grid_size = real_batch_size * H
+    if grid_size >= TARGET_NUM_CTAS:
+        block_DV = 128
+    elif grid_size * 2 >= TARGET_NUM_CTAS:
+        block_DV = 64
+    else:
+        block_DV = 32
+
+    tilelang_fused_chunk_gdr_fwd_kernel = tilelang_fused_chunk_gdr_fwd(
+        H,
+        Hg,
+        K,
+        V,
+        chunk_size,
+        scale,
+        qkva_dtype=q.dtype,
+        g_dtype=g.dtype,
+        b_dtype=b.dtype,
+        h0_dtype=initial_state.dtype,
+        ht_dtype=final_state.dtype,
+        h_dtype=h.dtype,
+        o_dtype=o.dtype,
+        seqlen_dtype=seqlen_dtype,
+        accum_dtype="float32",
+        use_initial_state=use_initial_state,
+        store_final_state=output_final_state,
+        store_h=output_h,
+        store_o=output_o,
+        is_varlen=is_varlen,
+        is_cp=is_cp,
+        block_DV=block_DV,
+    )
+    tilelang_fused_chunk_gdr_fwd_kernel(
+        q,
+        k,
+        v,
+        a,
+        g,
+        b,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        cp_seq_map,
+        raw_cu_seqlens,
+        o,
+        h,
+        final_state,
+    )
+
+    if not output_final_state:
+        final_state = None
+    if not output_h:
+        h = None
+    if not output_o:
+        o = None
+
+    return o, h, final_state

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/kkt_solve.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/kkt_solve.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+from typing import Optional
+
+import torch
+import tilelang
+import tilelang.language as T
+
+from flash_qla.utils import prepare_chunk_indices
+
+
+@tilelang.jit(
+    # out_idx=[-1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        # tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        # tilelang.PassConfigKey.TL_ENABLE_ASYNC_COPY: True,
+    },
+)
+def tilelang_kkt_solve(
+    H,
+    Hg,
+    DK,
+    chunk_size,
+    accum_dtype,
+    qkva_dtype,
+    b_dtype,
+    seqlen_dtype,
+    is_varlen,
+):
+    data_batch_size = T.dynamic("data_batch_size")
+    real_batch_size = T.dynamic("real_batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_chunks = T.dynamic("num_chunks")
+    block_S = chunk_size
+
+    k_shape = (data_batch_size, num_tokens, Hg, DK)
+    a_shape = (data_batch_size, num_tokens, H, chunk_size)
+    b_shape = (data_batch_size, num_tokens, H)
+
+    @T.macro
+    def kernel_body(
+        bb,
+        bc,
+        bh,
+        bhg,
+        batch_idx,
+        chunk_idx,
+        seq_start_idx,
+        seq_end_idx,
+        k,
+        b,
+        a,
+    ):
+        left = seq_start_idx + chunk_idx * block_S
+        right = left + block_S
+
+        k_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+        b_shared = T.alloc_shared((block_S), dtype=accum_dtype, scope="shared")
+        a64_fragment = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
+
+        a16i_row = T.alloc_fragment((4, 16), dtype=accum_dtype)
+        a16i_sum = T.alloc_fragment((4, 16), dtype=accum_dtype)
+
+        a16i_shared = T.alloc_shared((4, 17, 16), dtype=accum_dtype)
+        a16o_shared = T.alloc_shared((2, 17, 16), dtype=accum_dtype)
+        a16o_fragment = T.alloc_fragment((2, 16, 16), dtype=accum_dtype)
+
+        a32i_fragment = T.alloc_fragment((2, 32, 32), dtype=accum_dtype)
+        a32i0_shared = T.alloc_shared((32, 32), dtype=accum_dtype)
+        a32i1_shared = T.alloc_shared((32, 32), dtype=accum_dtype)
+        a32o_shared = T.alloc_shared((32, 32), dtype=accum_dtype)
+        a32o_fragment = T.alloc_fragment((32, 32), dtype=accum_dtype)
+
+        a64_shared = T.alloc_shared((block_S, block_S), dtype=qkva_dtype)
+
+        T.annotate_layout(
+            {
+                a16i_shared: tilelang.layout.make_linear_layout(a16i_shared),
+                a16o_shared: tilelang.layout.make_linear_layout(a16o_shared),
+            }
+        )
+
+        k_is_ready = T.alloc_barrier(arrive_count=32)
+        a_is_ready = T.alloc_barrier(arrive_count=128)
+
+        tx = T.get_thread_binding()
+
+        PRODUCER_NREG = 24
+        CONSUMER_NREG = 64
+
+        if tx < 128:
+            T.set_max_nreg(CONSUMER_NREG, 1)
+
+            # Load b
+            if right <= seq_end_idx:
+                for j_s in T.Parallel(block_S):
+                    b_shared[j_s] = b[bb, left + j_s, bh]
+            else:
+                for j_s in T.Parallel(block_S):
+                    if left + j_s < seq_end_idx:
+                        b_shared[j_s] = b[bb, left + j_s, bh]
+                    else:
+                        b_shared[j_s] = 0
+
+            T.barrier_wait(k_is_ready, 0)
+
+            # A = K @ K^T
+            T.gemm(k_shared, k_shared, a64_fragment, transpose_B=True, clear_accum=True)
+
+            # A = b * A
+            for j_s, j_t in T.Parallel(block_S, block_S):
+                a64_fragment[j_s, j_t] *= b_shared[j_s]
+
+            # A = I + StrictLower(A)
+            for j_s, j_t in T.Parallel(block_S, block_S):
+                if j_s < j_t:
+                    a64_fragment[j_s, j_t] = 0
+                elif j_s == j_t:
+                    a64_fragment[j_s, j_t] = 1
+
+            # Prepare inversion input
+            for j_s, j_t in T.Parallel(block_S, block_S):
+                if j_s >= 32 and j_t < 32:
+                    a32o_shared[j_s - 32, j_t] = -a64_fragment[j_s, j_t]
+                elif (j_s // 16) == (j_t // 16) + 1:
+                    a16o_shared[j_s // 32, j_s % 16, j_t % 16] = -a64_fragment[j_s, j_t]
+                elif (j_s // 16) == (j_t // 16):
+                    a16i_shared[j_s // 16, j_s % 16, j_t % 16] = a64_fragment[j_s, j_t]
+
+            # Diagonal 4x16x16
+            T.clear(a16i_row)
+            for k_s in T.unroll(1, 16):
+                for j_s, k_t in T.Parallel(4, 16):
+                    if k_t < k_s:
+                        a16i_row[j_s, k_t] = a16i_shared[j_s, k_s, k_t]
+                T.clear(a16i_sum)
+                for k_r in T.unroll(k_s):
+                    for j_s, k_t in T.Parallel(4, 16):
+                        a16i_sum[j_s, k_t] -= (
+                            a16i_shared[j_s, k_r, k_t] * a16i_row[j_s, k_r]
+                        )
+                for j_s, k_t in T.Parallel(4, 16):
+                    if k_t < k_s:
+                        a16i_shared[j_s, k_s, k_t] = a16i_sum[j_s, k_t]
+
+            # First level 2x16x16
+            T.clear(a16o_fragment)
+            for k_r in T.unroll(16):
+                for j_s, k_s, k_t in T.Parallel(2, 16, 16):
+                    a16o_fragment[j_s, k_s, k_t] += (
+                        a16i_shared[j_s * 2 + 1, k_s, k_r] * a16o_shared[j_s, k_r, k_t]
+                    )
+            for j_s, k_s, k_t in T.Parallel(2, 16, 16):
+                a16o_shared[j_s, k_t, k_s] = a16o_fragment[j_s, k_s, k_t]
+            T.clear(a16o_fragment)
+            for k_r in T.unroll(16):
+                for j_s, k_s, k_t in T.Parallel(2, 16, 16):
+                    a16o_fragment[j_s, k_s, k_t] += (
+                        a16o_shared[j_s, k_r, k_s] * a16i_shared[j_s * 2, k_r, k_t]
+                    )
+            T.copy(a16o_fragment, a16o_shared[:, 0:16, 0:16])
+
+            # Second level 1x32x32
+            for j_s, k_s, k_t in T.Parallel(2, 32, 32):
+                if k_s < 16 and k_t >= 16:
+                    a32i_fragment[j_s, k_s, k_t] = 0
+            for j_s, k_s, k_t in T.Parallel(2, 32, 32):
+                if k_s >= 16 and k_t < 16:
+                    a32i_fragment[j_s, k_s, k_t] = a16o_shared[j_s, k_s - 16, k_t]
+            for j_s, k_s, k_t in T.Parallel(2, 32, 32):
+                if k_s // 16 == k_t // 16:
+                    a32i_fragment[j_s, k_s, k_t] = a16i_shared[
+                        j_s * 2 + k_s // 16, k_s % 16, k_t % 16
+                    ]
+            for j_s, k_s, k_t in T.Parallel(2, 32, 32):
+                if j_s == 0:
+                    a32i0_shared[k_s, k_t] = a32i_fragment[j_s, k_s, k_t]
+                else:
+                    a32i1_shared[k_s, k_t] = a32i_fragment[j_s, k_s, k_t]
+            # TileLang 0.1.10 lowers T.gemm on f32 fragments to an unsupported
+            # SM100 mma_sync shape. These two 32x32 inversion GEMMs stay SIMT.
+            T.clear(a32o_fragment)
+            for k_s in T.unroll(32):
+                for j_s, j_t in T.Parallel(32, 32):
+                    a32o_fragment[j_s, j_t] += (
+                        a32i1_shared[j_s, k_s] * a32o_shared[k_s, j_t]
+                    )
+            T.copy(a32o_fragment, a32o_shared)
+            T.clear(a32o_fragment)
+            for k_s in T.unroll(32):
+                for j_s, j_t in T.Parallel(32, 32):
+                    a32o_fragment[j_s, j_t] += (
+                        a32o_shared[j_s, k_s] * a32i0_shared[k_s, j_t]
+                    )
+
+            # Combine inversion output
+            for j_s, k_s, k_t in T.Parallel(2, 32, 32):
+                a64_shared[j_s * 32 + k_s, j_s * 32 + k_t] = a32i_fragment[
+                    j_s, k_s, k_t
+                ]
+            for k_s, k_t in T.Parallel(32, 32):
+                a64_shared[32 + k_s, k_t] = a32o_fragment[k_s, k_t]
+            for k_s, k_t in T.Parallel(32, 32):
+                a64_shared[k_s, 32 + k_t] = 0
+
+            T.barrier_arrive(a_is_ready)
+
+        else:
+            T.set_max_nreg(PRODUCER_NREG, 0)
+
+            if tx < 128 + 32:
+                # Load K
+                T.copy(k[bb, left:right, bhg, 0:DK], k_shared)
+
+                T.barrier_arrive(k_is_ready)
+
+            elif tx < 128 + 64:
+                T.barrier_wait(a_is_ready, 0)
+
+                # Save A (unmasked)
+                if right <= seq_end_idx:
+                    T.copy(a64_shared, a[bb, left:right, bh, 0:block_S])
+
+            else:
+                T.barrier_wait(a_is_ready, 0)
+
+                # Save A (masked)
+                if right > seq_end_idx:
+                    for j_s, j_t in T.Parallel(block_S, block_S):
+                        if left + j_s < seq_end_idx:
+                            a[bb, left + j_s, bh, j_t] = a64_shared[j_s, j_t]
+
+    if is_varlen:
+
+        @T.prim_func
+        def tilelang_kkt_solve_kernel(
+            k: T.Tensor(k_shape, dtype=qkva_dtype),
+            b: T.Tensor(b_shape, dtype=b_dtype),
+            cu_seqlens: T.Tensor([real_batch_size + 1], dtype=seqlen_dtype),
+            chunk_indices: T.Tensor([num_chunks, 2], dtype=seqlen_dtype),
+            a: T.Tensor(a_shape, dtype=qkva_dtype),
+        ):
+            with T.Kernel(num_chunks * H, threads=256) as (bch,):
+                bc, bh = bch // H, bch % H
+                bhg = bh // (H // Hg)
+
+                batch_idx = T.alloc_var("int32")
+                chunk_idx = T.alloc_var("int32")
+                seq_start_idx = T.alloc_var("int32")
+                seq_end_idx = T.alloc_var("int32")
+
+                bb = 0
+                batch_idx = chunk_indices[bc, 0]
+                chunk_idx = chunk_indices[bc, 1]
+                seq_start_idx = cu_seqlens[batch_idx]
+                seq_end_idx = cu_seqlens[batch_idx + 1]
+
+                kernel_body(
+                    bb,
+                    bc,
+                    bh,
+                    bhg,
+                    batch_idx,
+                    chunk_idx,
+                    seq_start_idx,
+                    seq_end_idx,
+                    k,
+                    b,
+                    a,
+                )
+
+    else:
+
+        @T.prim_func
+        def tilelang_kkt_solve_kernel(
+            k: T.Tensor(k_shape, dtype=qkva_dtype),
+            b: T.Tensor(b_shape, dtype=b_dtype),
+            a: T.Tensor(a_shape, dtype=qkva_dtype),
+            num_chunks: T.int32,
+        ):
+            with T.Kernel(num_chunks * H, threads=256) as (bch,):
+                bc, bh = bch // H, bch % H
+                bhg = bh // (H // Hg)
+
+                batch_idx = T.alloc_var("int32")
+                chunk_idx = T.alloc_var("int32")
+                seq_start_idx = T.alloc_var("int32")
+                seq_end_idx = T.alloc_var("int32")
+
+                bb = bc % data_batch_size
+                batch_idx = bb
+                chunk_idx = bc // data_batch_size
+                seq_start_idx = 0
+                seq_end_idx = num_tokens
+
+                kernel_body(
+                    bb,
+                    bc,
+                    bh,
+                    bhg,
+                    batch_idx,
+                    chunk_idx,
+                    seq_start_idx,
+                    seq_end_idx,
+                    k,
+                    b,
+                    a,
+                )
+
+    return tilelang_kkt_solve_kernel
+
+
+def kkt_solve(
+    k: torch.Tensor,
+    b: torch.Tensor,
+    chunk_size: int = 64,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+):
+    batch_size, num_tokens, Hg, K = k.shape
+    _, _, H = b.shape
+    assert K == 128
+    assert chunk_size == 64
+
+    if cu_seqlens is None:
+        num_chunks = batch_size * tilelang.cdiv(num_tokens, chunk_size)
+        seqlen_dtype = "int32"
+        is_varlen = False
+    else:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+        seqlen_dtype = cu_seqlens.dtype
+        is_varlen = True
+
+    a = torch.empty(
+        (batch_size, num_tokens, H, chunk_size), dtype=k.dtype, device=k.device
+    )
+
+    tilelang_kkt_solve_kernel = tilelang_kkt_solve(
+        H,
+        Hg,
+        K,
+        chunk_size,
+        qkva_dtype=k.dtype,
+        b_dtype=b.dtype,
+        seqlen_dtype=seqlen_dtype,
+        accum_dtype="float32",
+        is_varlen=is_varlen,
+    )
+    if is_varlen:
+        tilelang_kkt_solve_kernel(k, b, cu_seqlens, chunk_indices, a)
+    else:
+        tilelang_kkt_solve_kernel(k, b, a, num_chunks)
+
+    return a

--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/prepare_h.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/prepare_h.py
@@ -1,0 +1,558 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import torch
+import tilelang
+import tilelang.language as T
+
+from flash_qla.utils import prepare_chunk_offsets
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+    },
+)
+def tilelang_prepare_h(
+    H,
+    Hg,
+    DK,
+    DV,
+    chunk_size,
+    accum_dtype,
+    qkva_dtype,
+    g_dtype,
+    b_dtype,
+    h0_dtype,
+    ht_dtype,
+    h_dtype,
+    seqlen_dtype,
+    use_initial_state,
+    store_final_state,
+    store_h,
+    is_varlen,
+    is_cp,
+    num_stages=2,
+):
+    batch_size = T.dynamic("batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_chunks = T.dynamic("num_chunks")
+    block_S = chunk_size
+
+    if is_varlen:
+        k_shape = (1, num_tokens, Hg, DK)
+        v_shape = (1, num_tokens, H, DV)
+        a_shape = (1, num_tokens, H, chunk_size)
+        g_shape = (1, num_tokens, H)
+        b_shape = (1, num_tokens, H)
+        h_shape = (1, num_chunks, H, DK, DV)
+    else:
+        k_shape = (batch_size, num_tokens, Hg, DK)
+        v_shape = (batch_size, num_tokens, H, DV)
+        a_shape = (batch_size, num_tokens, H, chunk_size)
+        g_shape = (batch_size, num_tokens, H)
+        b_shape = (batch_size, num_tokens, H)
+        h_shape = (batch_size, num_chunks, H, DK, DV)
+    h0_shape = (batch_size, H, DK, DV)
+    ht_shape = (batch_size, H, DK, DV)
+    m_shape = (batch_size, H, DK, DK)
+
+    @T.prim_func
+    def tilelang_prepare_h_kernel(
+        k: T.Tensor(k_shape, dtype=qkva_dtype),
+        v: T.Tensor(v_shape, dtype=qkva_dtype),
+        a: T.Tensor(a_shape, dtype=qkva_dtype),
+        g: T.Tensor(g_shape, dtype=g_dtype),
+        b: T.Tensor(b_shape, dtype=b_dtype),
+        h0: T.Tensor(h0_shape, dtype=h0_dtype),
+        cu_seqlens: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        chunk_offsets: T.Tensor([batch_size + 1], dtype=seqlen_dtype),
+        num_warmup_chunks: T.Tensor([batch_size, H], dtype=seqlen_dtype),
+        h: T.Tensor(h_shape, dtype=h_dtype),
+        ht: T.Tensor(ht_shape, dtype=ht_dtype),
+        mt: T.Tensor(m_shape, dtype=ht_dtype),
+    ):
+        with T.Kernel(batch_size * H, threads=512) as (bbh,):
+            bb, bh = bbh // H, bbh % H
+            bhg = bh // (H // Hg)
+
+            batch_idx = T.alloc_var("int32")
+            seq_start_idx = T.alloc_var("int32")
+            seq_end_idx = T.alloc_var("int32")
+            _seq_split_idx = T.alloc_var("int32")
+            chunk_start_idx = T.alloc_var("int32")
+            _chunk_split_idx = T.alloc_var("int32")
+
+            batch_idx = 0 if is_varlen else bb
+            seq_start_idx = cu_seqlens[bb] if is_varlen else 0
+            seq_end_idx = cu_seqlens[bb + 1] if is_varlen else num_tokens
+            chunk_start_idx = chunk_offsets[bb] if is_varlen else 0
+
+            num_iters = T.alloc_var("int32")
+            num_iters = (
+                num_warmup_chunks[bb, bh]
+                if is_cp
+                else T.ceildiv(seq_end_idx - seq_start_idx, block_S)
+            )
+
+            calc_mt = T.alloc_var("bool")
+            calc_mt = is_cp and num_iters >= T.ceildiv(
+                seq_end_idx - seq_start_idx, block_S
+            )
+            seq_start_idx = (
+                seq_end_idx - num_iters * block_S if is_cp else seq_start_idx
+            )
+
+            k_shared = T.alloc_shared((num_stages, block_S, DK), dtype=qkva_dtype)
+            v_shared = T.alloc_shared((num_stages, block_S, DV), dtype=qkva_dtype)
+            a_shared = T.alloc_shared((num_stages, block_S, block_S), dtype=qkva_dtype)
+            g_shared = T.alloc_shared(
+                (num_stages, block_S), dtype=accum_dtype, scope="shared"
+            )
+            b_shared = T.alloc_shared(
+                (num_stages, block_S), dtype=accum_dtype, scope="shared"
+            )
+            h_shared = T.alloc_shared((DK, DV), dtype=qkva_dtype)
+            x_shared = T.alloc_shared((block_S, DK), dtype=qkva_dtype)
+            y_shared = T.alloc_shared((block_S, DV), dtype=qkva_dtype)
+            m_shared_L = T.alloc_shared((DK, DK // 2), dtype=qkva_dtype)
+            m_shared_R = T.alloc_shared((DK, DK // 2), dtype=qkva_dtype)
+            z_shared_L = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
+            z_shared_R = T.alloc_shared((block_S, DK // 2), dtype=qkva_dtype)
+            g_rev_exp_shared = T.alloc_shared(
+                (block_S), dtype=accum_dtype, scope="shared"
+            )
+
+            h_fragment = T.alloc_fragment((DK, DV), dtype=accum_dtype)
+            x_fragment = T.alloc_fragment((block_S, DK), dtype=accum_dtype)
+            y_fragment = T.alloc_fragment((block_S, DV), dtype=accum_dtype)
+            m_fragment_L = T.alloc_fragment((DK, DK // 2), dtype=accum_dtype)
+            m_fragment_R = T.alloc_fragment((DK, DK // 2), dtype=accum_dtype)
+            z_fragment_L = T.alloc_fragment((block_S, DK // 2), dtype=accum_dtype)
+            z_fragment_R = T.alloc_fragment((block_S, DK // 2), dtype=accum_dtype)
+            g_last_local_S = T.alloc_local((1), dtype=accum_dtype)
+            g_last_local_X = T.alloc_local((1), dtype=accum_dtype)
+            g_last_local_Y = T.alloc_local((1), dtype=accum_dtype)
+            g_prod_X = T.alloc_fragment((1), dtype=accum_dtype)
+            g_prod_Y = T.alloc_fragment((1), dtype=accum_dtype)
+
+            data_is_ready = T.alloc_barrier(arrive_count=[96] * num_stages)
+            data_is_free = T.alloc_barrier(arrive_count=[384] * num_stages)
+
+            bar_0 = T.alloc_barrier(arrive_count=416)
+            bar_1 = T.alloc_barrier(arrive_count=256)
+            bar_2 = T.alloc_barrier(arrive_count=384)
+            bar_3 = T.alloc_barrier(arrive_count=128)
+
+            T.use_swizzle(10)
+
+            tx = T.get_thread_binding()
+
+            PRODUCER_NREG = 24
+            CONSUMER_S_NREG = 168
+            CONSUMER_X_NREG = 160
+            CONSUMER_Y_NREG = 160
+
+            if tx < 128:
+                T.set_max_nreg(CONSUMER_S_NREG, 1)
+
+                # Initialize S
+                if use_initial_state:
+                    T.copy(h0[bb, bh, 0:DK, 0:DV], h_fragment)
+                else:
+                    T.clear(h_fragment)
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE = i_s % num_stages]
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE = i_s % num_stages] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # S4[1] S
+                    T.copy(h_fragment, h_shared)
+                    T.barrier_arrive(bar_1)
+
+                    # [STAGE = i_s % num_stages] 1
+                    T.barrier_wait(bar_1, i_s % 2)
+                    # S = g_last * S
+                    g_last_local_S[0] = T.exp2(
+                        g_shared[i_s % num_stages, block_S - 1] * 1.442695
+                    )
+                    for j_k, j_v in T.Parallel(DK, DV):
+                        h_fragment[j_k, j_v] *= g_last_local_S[0]
+                    T.barrier_arrive(bar_2)
+
+                    # [STAGE = i_s % num_stages] 2
+                    T.barrier_wait(bar_2, i_s % 2)
+                    # S += X^T @ Y
+                    T.gemm(
+                        x_shared,
+                        y_shared,
+                        h_fragment,
+                        transpose_A=True,
+                        clear_accum=False,
+                    )
+                    T.barrier_arrive(bar_3)
+
+                    T.barrier_arrive(data_is_free[i_s % num_stages])
+
+                # Store final S
+                if store_final_state:
+                    T.copy(h_fragment, ht[bb, bh, 0:DK, 0:DV])
+
+            elif tx < 256:
+                T.set_max_nreg(CONSUMER_X_NREG, 1)
+
+                if calc_mt:
+                    for j_k, j_v in T.Parallel(DK, DK // 2):
+                        if j_k == j_v + DK // 2:
+                            m_fragment_R[j_k, j_v] = 1
+                        else:
+                            m_fragment_R[j_k, j_v] = 0
+                    g_prod_X[0] = 0
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE = i_s % num_stages]
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE = i_s % num_stages] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # X = A^T @ K
+                    T.gemm(
+                        a_shared[i_s % num_stages, :, :],
+                        k_shared[i_s % num_stages, :, :],
+                        x_fragment,
+                        transpose_A=True,
+                        clear_accum=True,
+                    )
+
+                    # [STAGE = i_s % num_stages] 1
+                    # X = - b * X
+                    for j_s, j_k in T.Parallel(block_S, DK):
+                        x_fragment[j_s, j_k] *= -b_shared[i_s % num_stages, j_s]
+                    # S2[1] X
+                    T.copy(x_fragment, x_shared)
+                    T.barrier_arrive(bar_2)
+
+                    if calc_mt:
+                        # [STAGE = i_s % num_stages] 2
+                        g_prod_X[0] += g_shared[i_s % num_stages, block_S - 1]
+                        # S4[2] M
+                        T.copy(m_fragment_R, m_shared_R)
+
+                        # [STAGE = i_s % num_stages] 3
+                        T.barrier_wait(bar_3, i_s % 2)
+                        # Z = K @ M
+                        T.gemm(
+                            k_shared[i_s % num_stages, :, :],
+                            m_shared_R,
+                            z_fragment_R,
+                            clear_accum=True,
+                        )
+                        # S4[2] Z
+                        T.copy(z_fragment_R, z_shared_R)
+                        # M += X^T @ Z
+                        T.gemm(
+                            x_shared,
+                            z_shared_R,
+                            m_fragment_R,
+                            transpose_A=True,
+                            clear_accum=False,
+                        )
+
+                    T.barrier_arrive(data_is_free[i_s % num_stages])
+
+                if calc_mt:
+                    g_last_local_X[0] = T.exp2(g_prod_X[0] * 1.442695)
+                    for j_k, j_v in T.Parallel(DK, DK // 2):
+                        m_fragment_R[j_k, j_v] *= g_last_local_X[0]
+                    T.copy(m_fragment_R, mt[bb, bh, 0:DK, DK // 2 :])
+
+            elif tx < 384:
+                T.set_max_nreg(CONSUMER_Y_NREG, 1)
+
+                if calc_mt:
+                    for j_k, j_v in T.Parallel(DK, DK // 2):
+                        if j_k == j_v:
+                            m_fragment_L[j_k, j_v] = 1
+                        else:
+                            m_fragment_L[j_k, j_v] = 0
+                    g_prod_Y[0] = 0
+
+                # Main Loop
+                for i_s in T.serial(num_iters):
+                    # [STAGE = i_s % num_stages]
+                    T.barrier_wait(
+                        data_is_ready[i_s % num_stages], (i_s // num_stages + 0) % 2
+                    )
+                    T.barrier_arrive(bar_0)
+
+                    # [STAGE = i_s % num_stages] 0
+                    T.barrier_wait(bar_0, i_s % 2)
+                    # Precompute g_last/g
+                    g_last_local_Y[0] = g_shared[i_s % num_stages, block_S - 1]
+                    for j_s in T.Parallel(block_S):
+                        g_rev_exp_shared[j_s] = T.exp2(
+                            (g_last_local_Y[0] - g_shared[i_s % num_stages, j_s])
+                            * 1.442695
+                        )
+                    g_last_local_Y[0] = T.exp2(g_last_local_Y[0] * 1.442695)
+                    T.barrier_arrive(bar_1)
+
+                    # [STAGE = i_s % num_stages] 1
+                    T.barrier_wait(bar_1, i_s % 2)
+                    # U = K @ S
+                    T.gemm(
+                        k_shared[i_s % num_stages, :, :],
+                        h_shared,
+                        y_fragment,
+                        clear_accum=True,
+                    )
+                    # Y = g_last * U - g_last/g * V
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        y_fragment[j_s, j_v] *= g_last_local_Y[0]
+                    for j_s, j_v in T.Parallel(block_S, DV):
+                        y_fragment[j_s, j_v] -= (
+                            v_shared[i_s % num_stages, j_s, j_v] * g_rev_exp_shared[j_s]
+                        )
+                    # S2[2] Y
+                    T.copy(y_fragment, y_shared)
+                    T.barrier_arrive(bar_2)
+
+                    if calc_mt:
+                        # [STAGE = i_s % num_stages] 2
+                        g_prod_Y[0] += g_shared[i_s % num_stages, block_S - 1]
+                        # S4[2] M
+                        T.copy(m_fragment_L, m_shared_L)
+
+                        # [STAGE = i_s % num_stages] 3
+                        T.barrier_wait(bar_3, i_s % 2)
+                        # Z = K @ M
+                        T.gemm(
+                            k_shared[i_s % num_stages, :, :],
+                            m_shared_L,
+                            z_fragment_L,
+                            clear_accum=True,
+                        )
+                        # S4[2] Z
+                        T.copy(z_fragment_L, z_shared_L)
+                        # M += X^T @ Z
+                        T.gemm(
+                            x_shared,
+                            z_shared_L,
+                            m_fragment_L,
+                            transpose_A=True,
+                            clear_accum=False,
+                        )
+
+                    T.barrier_arrive(data_is_free[i_s % num_stages])
+
+                if calc_mt:
+                    g_last_local_Y[0] = T.exp2(g_prod_Y[0] * 1.442695)
+                    for j_k, j_v in T.Parallel(DK, DK // 2):
+                        m_fragment_L[j_k, j_v] *= g_last_local_Y[0]
+                    T.copy(m_fragment_L, mt[bb, bh, 0:DK, : DK // 2])
+
+            else:
+                T.set_max_nreg(PRODUCER_NREG, 0)
+
+                if tx < 384 + 32:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load K
+                        T.copy(
+                            k[batch_idx, left:right, bhg, 0:DK],
+                            k_shared[i_s % num_stages, :, :],
+                        )
+
+                        T.barrier_arrive(data_is_ready[i_s % num_stages])
+
+                elif tx < 384 + 64:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load V
+                        T.copy(
+                            v[batch_idx, left:right, bh, 0:DV],
+                            v_shared[i_s % num_stages, :, :],
+                        )
+                        # Load A  TODO: Mask A for the last chunk
+                        T.copy(
+                            a[batch_idx, left:right, bh, 0:block_S],
+                            a_shared[i_s % num_stages, :, :],
+                        )
+
+                        T.barrier_arrive(data_is_ready[i_s % num_stages])
+
+                elif tx < 384 + 96:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_wait(
+                            data_is_free[i_s % num_stages], (i_s // num_stages + 1) % 2
+                        )
+                        left = seq_start_idx + i_s * block_S
+                        right = left + block_S
+
+                        # Load gamma
+                        if right <= seq_end_idx:
+                            for j_s in T.Parallel(block_S):
+                                g_shared[i_s % num_stages, j_s] = g[
+                                    batch_idx, left + j_s, bh
+                                ]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    g_shared[i_s % num_stages, j_s] = g[
+                                        batch_idx, left + j_s, bh
+                                    ]
+                                else:
+                                    g_shared[i_s % num_stages, j_s] = g[
+                                        batch_idx, seq_end_idx - 1, bh
+                                    ]
+                        # Load beta
+                        if right <= seq_end_idx:
+                            for j_s in T.Parallel(block_S):
+                                b_shared[i_s % num_stages, j_s] = b[
+                                    batch_idx, left + j_s, bh
+                                ]
+                        else:
+                            for j_s in T.Parallel(block_S):
+                                if left + j_s < seq_end_idx:
+                                    b_shared[i_s % num_stages, j_s] = b[
+                                        batch_idx, left + j_s, bh
+                                    ]
+                                else:
+                                    b_shared[i_s % num_stages, j_s] = 0
+
+                        T.barrier_arrive(data_is_ready[i_s % num_stages])
+
+                else:
+                    for i_s in T.serial(num_iters):
+                        T.barrier_arrive(bar_0)
+
+                        T.barrier_wait(bar_0, i_s % 2)
+                        T.barrier_wait(bar_1, i_s % 2)
+                        # Store S
+                        if store_h:
+                            T.copy(
+                                h_shared,
+                                h[batch_idx, chunk_start_idx + i_s, bh, 0:DK, 0:DV],
+                            )
+
+    return tilelang_prepare_h_kernel
+
+
+def fused_gdr_h(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    g: torch.Tensor,
+    b: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = True,
+    output_h: bool = True,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+    num_warmup_chunks: torch.LongTensor | None = None,
+):
+    batch_size, num_tokens, Hg, K = k.shape
+    _, _, H, V = v.shape
+    assert K == V == 128
+    assert chunk_size == 64
+
+    if cu_seqlens is None:
+        assert num_warmup_chunks is None
+        real_batch_size = batch_size
+        num_chunks = tilelang.cdiv(num_tokens, chunk_size) if output_h else 0
+        cu_seqlens = torch.empty((batch_size + 1), dtype=torch.int32, device=k.device)
+        chunk_offsets = torch.empty(
+            (batch_size + 1), dtype=torch.int32, device=k.device
+        )
+        is_varlen = False
+        is_cp = False
+    else:
+        real_batch_size = len(cu_seqlens) - 1
+        chunk_offsets, num_chunks = prepare_chunk_offsets(cu_seqlens, chunk_size)
+        chunk_offsets = chunk_offsets.to(cu_seqlens.dtype)
+        num_chunks = num_chunks if output_h else 0
+        is_varlen = True
+        if num_warmup_chunks is None:
+            num_warmup_chunks = torch.empty(
+                (real_batch_size, H), dtype=cu_seqlens.dtype, device=k.device
+            )
+            is_cp = False
+        else:
+            is_cp = True
+
+    use_initial_state = initial_state is not None
+    if initial_state is None:
+        initial_state = torch.empty(
+            (real_batch_size, H, K, V), dtype=torch.float32, device=k.device
+        )
+    h = torch.empty((batch_size, num_chunks, H, K, V), dtype=k.dtype, device=k.device)
+    ht_dtype = k.dtype if is_cp else torch.float32
+    final_state = torch.empty(
+        (real_batch_size, H, K, V), dtype=ht_dtype, device=k.device
+    )
+    final_correction = torch.empty(
+        (real_batch_size, H, K, K), dtype=ht_dtype, device=k.device
+    )
+
+    tilelang_prepare_h_kernel = tilelang_prepare_h(
+        H,
+        Hg,
+        K,
+        V,
+        chunk_size,
+        qkva_dtype=k.dtype,
+        g_dtype=g.dtype,
+        b_dtype=b.dtype,
+        h0_dtype=initial_state.dtype,
+        ht_dtype=final_state.dtype,
+        h_dtype=h.dtype,
+        seqlen_dtype=cu_seqlens.dtype,
+        accum_dtype="float32",
+        use_initial_state=use_initial_state,
+        store_final_state=output_final_state,
+        store_h=output_h,
+        is_varlen=is_varlen,
+        is_cp=is_cp,
+    )
+    tilelang_prepare_h_kernel(
+        k,
+        v,
+        a,
+        g,
+        b,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        num_warmup_chunks,
+        h,
+        final_state,
+        final_correction,
+    )
+
+    if not output_final_state:
+        final_state = None
+        final_correction = None
+    if not output_h:
+        h = None
+
+    return h, final_state, final_correction

--- a/flash_qla/ops/gated_delta_rule/chunk/cp_context.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/cp_context.py
@@ -8,13 +8,38 @@ import tilelang
 
 from flash_qla.utils import tensor_cache
 
-if tilelang.contrib.nvcc.get_target_compute_version() == "9.0":
+_target_compute_version = tilelang.contrib.nvcc.get_target_compute_version()
+if _target_compute_version == "9.0":
     from .hopper import get_warmup_chunks, fused_gdr_h, correct_initial_states
+
+    _chunk_backend = "hopper"
+elif _target_compute_version == "10.0":
+    from .blackwell import get_warmup_chunks, fused_gdr_h, correct_initial_states
+
+    _chunk_backend = "blackwell"
 else:
-    raise ValueError("FlashQLA now support sm90 only.")
+    raise ValueError("FlashQLA now supports sm90/sm100 only.")
 
 
 MULTI_PROCESSOR_COUNT = torch.cuda.get_device_properties().multi_processor_count
+
+
+def _check_backend_matches_device(x: torch.Tensor):
+    if not x.is_cuda:
+        return
+    major = torch.cuda.get_device_capability(x.device)[0]
+    if major >= 10 and _chunk_backend != "blackwell":
+        raise RuntimeError(
+            "FlashQLA was imported with the SM90/Hopper TileLang target, but the "
+            "input tensor is on an SM100+ Blackwell GPU. Re-import FlashQLA with "
+            "TileLang target 10.0 enabled."
+        )
+    if major == 9 and _chunk_backend != "hopper":
+        raise RuntimeError(
+            "FlashQLA was imported with the SM100/Blackwell TileLang target, but "
+            "the input tensor is on an SM90 Hopper GPU. Re-import FlashQLA with "
+            "TileLang target 9.0 enabled."
+        )
 
 
 @tensor_cache
@@ -113,6 +138,7 @@ def intra_card_cp_preprocess(
     raw_cu_seqlens: torch.Tensor,
     warmup_threshold: float = -10.0,
 ):
+    _check_backend_matches_device(k)
     batch_size, num_tokens, num_k_heads, k_head_dim = k.shape
     _, _, num_v_heads, v_head_dim = v.shape
     chunk_size = a.shape[-1]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "torch>=2.8",
-        "tilelang==0.1.8",
+        "tilelang==0.1.10",
         "apache-tvm-ffi==0.1.9",
     ],
     zip_safe=False,

--- a/tests/ref_gdr.py
+++ b/tests/ref_gdr.py
@@ -203,7 +203,7 @@ def torch_chunk_gdr_fwd(
 
     if cu_seqlens is not None:
         vn = pack(vn, cu_seqlens)
-        h = pack(h, prepare_chunk_offsets(cu_seqlens, chunk_size))
+        h = pack(h, prepare_chunk_offsets(cu_seqlens, chunk_size)[0])
 
     return h, vn, last_state
 
@@ -223,7 +223,7 @@ def torch_chunk_o_fwd(
         k = unpack(k, cu_seqlens)
         v = unpack(v, cu_seqlens)
         g = unpack(g, cu_seqlens)
-        h = unpack(h, prepare_chunk_offsets(cu_seqlens, chunk_size))
+        h = unpack(h, prepare_chunk_offsets(cu_seqlens, chunk_size)[0])
 
     batch_size, num_tokens, num_k_heads, head_dim_k = k.shape
     _, _, num_v_heads, head_dim_v = v.shape
@@ -379,7 +379,7 @@ def torch_chunk_gdr_bwd(
     dv = dv.reshape((batch_size, -1, num_v_heads, head_dim_v))[:, :num_tokens]
     if cu_seqlens is not None:
         dv = pack(dv, cu_seqlens)
-        dh = pack(dh, prepare_chunk_offsets(cu_seqlens, chunk_size))
+        dh = pack(dh, prepare_chunk_offsets(cu_seqlens, chunk_size)[0])
     return dh, dh0, dv
 
 
@@ -405,8 +405,8 @@ def torch_chunk_dqkwg_bwd(
         g = unpack(g, cu_seqlens)
         do = unpack(do, cu_seqlens)
         dv = unpack(dv, cu_seqlens)
-        h = unpack(h, prepare_chunk_offsets(cu_seqlens, chunk_size))
-        dh = unpack(dh, prepare_chunk_offsets(cu_seqlens, chunk_size))
+        h = unpack(h, prepare_chunk_offsets(cu_seqlens, chunk_size)[0])
+        dh = unpack(dh, prepare_chunk_offsets(cu_seqlens, chunk_size)[0])
 
     batch_size, num_tokens, num_k_heads, head_dim_k = k.shape
     _, _, num_v_heads, head_dim_v = do.shape

--- a/tests/test_blackwell_gdr.py
+++ b/tests/test_blackwell_gdr.py
@@ -278,7 +278,7 @@ def _run_blackwell_precision_case(
         _assert_close(f"{name}.run{run_idx}.dk", dk_ref, dk_qla.float(), ratio=0.03)
         _assert_close(f"{name}.run{run_idx}.dv", dv_ref, dv_qla.float(), ratio=0.03)
         _assert_close(f"{name}.run{run_idx}.dbeta", db_ref, db_qla.float(), ratio=0.03)
-        _assert_close(f"{name}.run{run_idx}.dg", dg_ref, dg_qla.float(), ratio=0.03)
+        _assert_close(f"{name}.run{run_idx}.dg", dg_ref, dg_qla.float(), ratio=0.05)
         if dht is not None:
             _assert_close(
                 f"{name}.run{run_idx}.dh0", dh0_ref, dh0_qla.float(), ratio=0.03

--- a/tests/test_blackwell_gdr.py
+++ b/tests/test_blackwell_gdr.py
@@ -28,6 +28,7 @@ def _requires_blackwell():
 
 
 def _assert_close(name: str, ref: torch.Tensor, got: torch.Tensor, ratio: float = 0.02):
+    assert torch.isfinite(ref).all(), f"{name}: non-finite reference"
     assert torch.isfinite(got).all(), f"{name}: non-finite output"
     diff = (got - ref).abs().max().item()
     base = ref.abs().max().item()
@@ -44,25 +45,101 @@ def _assert_close(name: str, ref: torch.Tensor, got: torch.Tensor, ratio: float 
 
 @pytest.mark.skipif(
     _requires_blackwell(),
-    reason="FlashQLA Blackwell precision test requires an sm100+ CUDA GPU",
+    reason="FlashQLA Blackwell contract test requires an sm100+ CUDA GPU",
 )
-def test_blackwell_gdr_fused_path_matches_reference():
-    from flash_qla import chunk_gated_delta_rule_bwd, chunk_gated_delta_rule_fwd
+def test_blackwell_backend_and_auto_cp_contract():
+    import tilelang
+    from flash_qla import chunk_gated_delta_rule_fwd
     import flash_qla.ops.gated_delta_rule.chunk as chunk_backend
     from flash_qla.ops.gated_delta_rule.chunk.blackwell import (
         correct_initial_states,
         get_warmup_chunks,
     )
     from flash_qla.utils import l2norm
-    from ref_gdr import chunk_gated_delta_rule_bwd as chunk_gated_delta_rule_bwd_ref
-    from ref_gdr import chunk_gated_delta_rule_fwd as chunk_gated_delta_rule_fwd_ref
 
-    torch.manual_seed(42)
-    batch_size, num_tokens, num_k_heads, num_v_heads = 1, 512, 4, 12
-    head_dim = 128
-    dtype = torch.bfloat16
     device = torch.device("cuda")
+    dtype = torch.bfloat16
+    batch_size, num_tokens, num_k_heads, num_v_heads, head_dim = 1, 128, 2, 6, 128
+    q = l2norm(
+        torch.randn(
+            batch_size, num_tokens, num_k_heads, head_dim, device=device, dtype=dtype
+        )
+    )
+    k = l2norm(
+        torch.randn(
+            batch_size, num_tokens, num_k_heads, head_dim, device=device, dtype=dtype
+        )
+    )
+    v = torch.randn(
+        batch_size, num_tokens, num_v_heads, head_dim, device=device, dtype=dtype
+    )
+    g = (
+        torch.nn.functional.logsigmoid(
+            torch.randn(
+                batch_size, num_tokens, num_v_heads, device=device, dtype=torch.float32
+            )
+        )
+        / 16
+    )
+    beta = torch.randn(
+        batch_size, num_tokens, num_v_heads, device=device, dtype=torch.float32
+    ).sigmoid()
 
+    assert tilelang.contrib.nvcc.get_target_compute_version() == "10.0"
+    assert chunk_backend._chunk_backend == "blackwell"
+    assert ".blackwell." in chunk_backend.fused_gdr_fwd.__module__
+    print(
+        f"blackwell_gdr_backend backend={chunk_backend._chunk_backend} "
+        f"fwd_module={chunk_backend.fused_gdr_fwd.__module__}",
+        flush=True,
+    )
+
+    original_backend = chunk_backend._chunk_backend
+    chunk_backend._chunk_backend = "hopper"
+    try:
+        with pytest.raises(RuntimeError, match="SM90/Hopper TileLang target"):
+            chunk_gated_delta_rule_fwd(q=q, k=k, v=v, g=g, beta=beta, auto_cp=False)
+    finally:
+        chunk_backend._chunk_backend = original_backend
+
+    cp_cu_seqlens = torch.tensor([0, 64, 128], device=device, dtype=torch.int32)
+    ht_mask = torch.tensor([False, True], device=device)
+    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
+        get_warmup_chunks(
+            g=g,
+            cu_seqlens=cp_cu_seqlens,
+            ht_mask=ht_mask,
+            chunk_size=64,
+            threshold=-10.0,
+        )
+    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
+        correct_initial_states(
+            raw_h0=torch.empty(1, num_v_heads, head_dim, head_dim, device=device),
+            ht_buffer=torch.empty(2, num_v_heads, head_dim, head_dim, device=device),
+            mt_buffer=torch.empty(2, num_v_heads, device=device),
+            fallback_mask=torch.empty(2, num_v_heads, dtype=torch.bool, device=device),
+            seq_map_r2c=torch.tensor([0, 2], device=device, dtype=torch.int32),
+        )
+    with pytest.raises(RuntimeError, match="auto_cp=True is not supported on SM100"):
+        chunk_gated_delta_rule_fwd(q=q, k=k, v=v, g=g, beta=beta, auto_cp=True)
+
+
+def _make_inputs(
+    *,
+    seed: int,
+    batch_size: int,
+    num_tokens: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_dim: int,
+    cu_seqlens_values: tuple[int, ...] | None,
+    use_initial_state: bool,
+):
+    from flash_qla.utils import l2norm
+
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
     q = l2norm(
         torch.randn(
             batch_size, num_tokens, num_k_heads, head_dim, device=device, dtype=dtype
@@ -88,114 +165,169 @@ def test_blackwell_gdr_fused_path_matches_reference():
         batch_size, num_tokens, num_v_heads, device=device, dtype=torch.float32
     ).sigmoid()
     do = torch.randn_like(v)
-    scale = head_dim**-0.5
+    cu_seqlens = None
+    real_batch_size = batch_size
+    if cu_seqlens_values is not None:
+        assert batch_size == 1
+        assert cu_seqlens_values[0] == 0 and cu_seqlens_values[-1] == num_tokens
+        cu_seqlens = torch.tensor(cu_seqlens_values, device=device, dtype=torch.int32)
+        real_batch_size = len(cu_seqlens_values) - 1
+    h0 = None
+    dht = None
+    if use_initial_state:
+        h0 = torch.randn(
+            real_batch_size,
+            num_v_heads,
+            head_dim,
+            head_dim,
+            device=device,
+            dtype=torch.float32,
+        )
+        dht = torch.randn_like(h0) / 8
+    return q, k, v, g, beta, do, h0, dht, cu_seqlens
 
-    assert chunk_backend._chunk_backend == "blackwell"
-    assert ".blackwell." in chunk_backend.fused_gdr_fwd.__module__
-    print(
-        f"blackwell_gdr_backend backend={chunk_backend._chunk_backend} "
-        f"fwd_module={chunk_backend.fused_gdr_fwd.__module__}",
-        flush=True,
+
+def _run_blackwell_precision_case(
+    *,
+    name: str,
+    seed: int,
+    batch_size: int,
+    num_tokens: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    cu_seqlens_values: tuple[int, ...] | None = None,
+    use_initial_state: bool = False,
+    repeat: int = 3,
+):
+    from flash_qla import chunk_gated_delta_rule_bwd, chunk_gated_delta_rule_fwd
+    from ref_gdr import chunk_gated_delta_rule_bwd as chunk_gated_delta_rule_bwd_ref
+    from ref_gdr import chunk_gated_delta_rule_fwd as chunk_gated_delta_rule_fwd_ref
+
+    head_dim = 128
+    scale = head_dim**-0.5
+    q, k, v, g, beta, do, h0, dht, cu_seqlens = _make_inputs(
+        seed=seed,
+        batch_size=batch_size,
+        num_tokens=num_tokens,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_dim=head_dim,
+        cu_seqlens_values=cu_seqlens_values,
+        use_initial_state=use_initial_state,
     )
 
-    original_backend = chunk_backend._chunk_backend
-    chunk_backend._chunk_backend = "hopper"
-    try:
-        with pytest.raises(RuntimeError, match="SM90/Hopper TileLang target"):
-            chunk_gated_delta_rule_fwd(
-                q=q,
-                k=k,
-                v=v,
-                g=g,
-                beta=beta,
-                scale=scale,
-                auto_cp=False,
-            )
-    finally:
-        chunk_backend._chunk_backend = original_backend
-
-    cp_cu_seqlens = torch.tensor([0, 256, 512], device=device, dtype=torch.int32)
-    ht_mask = torch.tensor([False, True], device=device)
-    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
-        get_warmup_chunks(
-            g=g,
-            cu_seqlens=cp_cu_seqlens,
-            ht_mask=ht_mask,
-            chunk_size=64,
-            threshold=-10.0,
-        )
-    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
-        correct_initial_states(
-            raw_h0=torch.empty(1, num_v_heads, head_dim, head_dim, device=device),
-            ht_buffer=torch.empty(2, num_v_heads, head_dim, head_dim, device=device),
-            mt_buffer=torch.empty(2, num_v_heads, device=device),
-            fallback_mask=torch.empty(2, num_v_heads, dtype=torch.bool, device=device),
-            seq_map_r2c=torch.tensor([0, 2], device=device, dtype=torch.int32),
-        )
-
-    with pytest.raises(RuntimeError, match="auto_cp=True is not supported on SM100"):
-        chunk_gated_delta_rule_fwd(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            scale=scale,
-            auto_cp=True,
-        )
-
-    g_ref, o_ref, A_ref, _, _ = chunk_gated_delta_rule_fwd_ref(
+    g_ref, o_ref, A_ref, h_ref, final_ref = chunk_gated_delta_rule_fwd_ref(
         q=q.float(),
         k=k.float(),
         v=v.float(),
         g=g.float(),
         beta=beta.float(),
         scale=scale,
+        initial_state=h0,
+        cu_seqlens=cu_seqlens,
     )
-    g_qla, A_qla, o_qla, _, _ = chunk_gated_delta_rule_fwd(
-        q=q,
-        k=k,
-        v=v,
-        g=g,
-        beta=beta,
-        scale=scale,
-        output_final_state=True,
-        output_h=False,
-        auto_cp=None,
-    )
-
-    _assert_close("g", g_ref, g_qla.float(), ratio=0.002)
-    _assert_close("o", o_ref, o_qla.float(), ratio=0.02)
-
-    dq_ref, dk_ref, dv_ref, db_ref, dg_ref, _ = chunk_gated_delta_rule_bwd_ref(
+    dq_ref, dk_ref, dv_ref, db_ref, dg_ref, dh0_ref = chunk_gated_delta_rule_bwd_ref(
         q.float(),
         k.float(),
         v.float(),
         g_ref,
         beta.float(),
-        A_ref,
+        A_ref.float(),
         scale,
-        None,
+        h0,
         do.float(),
-        None,
-        None,
-    )
-    dq_qla, dk_qla, dv_qla, db_qla, dg_qla, _ = chunk_gated_delta_rule_bwd(
-        q,
-        k,
-        v,
-        g_qla,
-        beta,
-        A_qla,
-        do,
-        None,
-        scale,
-        None,
-        None,
+        dht,
+        cu_seqlens,
     )
 
-    _assert_close("dq", dq_ref, dq_qla.float(), ratio=0.03)
-    _assert_close("dk", dk_ref, dk_qla.float(), ratio=0.03)
-    _assert_close("dv", dv_ref, dv_qla.float(), ratio=0.03)
-    _assert_close("dbeta", db_ref, db_qla.float(), ratio=0.03)
-    _assert_close("dg", dg_ref, dg_qla.float(), ratio=0.03)
+    for run_idx in range(repeat):
+        g_qla, A_qla, o_qla, h_qla, final_qla = chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=h0,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            output_h=True,
+            auto_cp=None,
+        )
+        _assert_close(f"{name}.run{run_idx}.g", g_ref, g_qla.float(), ratio=0.002)
+        _assert_close(f"{name}.run{run_idx}.o", o_ref, o_qla.float(), ratio=0.02)
+        _assert_close(f"{name}.run{run_idx}.h", h_ref, h_qla.float(), ratio=0.03)
+        _assert_close(
+            f"{name}.run{run_idx}.final_state", final_ref, final_qla.float(), ratio=0.03
+        )
+
+        dq_qla, dk_qla, dv_qla, db_qla, dg_qla, dh0_qla = chunk_gated_delta_rule_bwd(
+            q,
+            k,
+            v,
+            g_qla,
+            beta,
+            A_qla,
+            do,
+            dht,
+            scale,
+            h0,
+            cu_seqlens,
+        )
+        _assert_close(f"{name}.run{run_idx}.dq", dq_ref, dq_qla.float(), ratio=0.03)
+        _assert_close(f"{name}.run{run_idx}.dk", dk_ref, dk_qla.float(), ratio=0.03)
+        _assert_close(f"{name}.run{run_idx}.dv", dv_ref, dv_qla.float(), ratio=0.03)
+        _assert_close(f"{name}.run{run_idx}.dbeta", db_ref, db_qla.float(), ratio=0.03)
+        _assert_close(f"{name}.run{run_idx}.dg", dg_ref, dg_qla.float(), ratio=0.03)
+        if dht is not None:
+            _assert_close(
+                f"{name}.run{run_idx}.dh0", dh0_ref, dh0_qla.float(), ratio=0.03
+            )
+
+
+@pytest.mark.skipif(
+    _requires_blackwell(),
+    reason="FlashQLA Blackwell precision test requires an sm100+ CUDA GPU",
+)
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            dict(
+                name="full_chunks",
+                seed=42,
+                batch_size=1,
+                num_tokens=512,
+                num_k_heads=4,
+                num_v_heads=12,
+            ),
+            id="full_chunks",
+        ),
+        pytest.param(
+            dict(
+                name="partial_initial_state",
+                seed=43,
+                batch_size=1,
+                num_tokens=575,
+                num_k_heads=2,
+                num_v_heads=6,
+                use_initial_state=True,
+            ),
+            id="partial_initial_state",
+        ),
+        pytest.param(
+            dict(
+                name="varlen_partial",
+                seed=44,
+                batch_size=1,
+                num_tokens=575,
+                num_k_heads=2,
+                num_v_heads=6,
+                cu_seqlens_values=(0, 63, 130, 575),
+            ),
+            id="varlen_partial",
+        ),
+    ],
+)
+def test_blackwell_gdr_fused_path_matches_reference(case):
+    _run_blackwell_precision_case(**case)

--- a/tests/test_blackwell_gdr.py
+++ b/tests/test_blackwell_gdr.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _add_tilelang_bundled_tvm_to_path():
+    if importlib.util.find_spec("tvm") is not None:
+        return
+    tilelang_spec = importlib.util.find_spec("tilelang")
+    if tilelang_spec is None or tilelang_spec.origin is None:
+        return
+    tvm_python = Path(tilelang_spec.origin).parent / "3rdparty" / "tvm" / "python"
+    if tvm_python.exists():
+        sys.path.append(str(tvm_python))
+
+
+_add_tilelang_bundled_tvm_to_path()
+
+
+def _requires_blackwell():
+    return not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10
+
+
+def _assert_close(name: str, ref: torch.Tensor, got: torch.Tensor, ratio: float = 0.02):
+    assert torch.isfinite(got).all(), f"{name}: non-finite output"
+    diff = (got - ref).abs().max().item()
+    base = ref.abs().max().item()
+    limit = base * ratio + 1e-4
+    print(
+        f"blackwell_gdr_metric name={name} "
+        f"max_abs={diff:.6g} limit={limit:.6g} ref_max={base:.6g}",
+        flush=True,
+    )
+    assert diff <= limit, (
+        f"{name}: max_abs={diff:.6g} limit={limit:.6g} ref_max={base:.6g}"
+    )
+
+
+@pytest.mark.skipif(
+    _requires_blackwell(),
+    reason="FlashQLA Blackwell precision test requires an sm100+ CUDA GPU",
+)
+def test_blackwell_gdr_fused_path_matches_reference():
+    from flash_qla import chunk_gated_delta_rule_bwd, chunk_gated_delta_rule_fwd
+    import flash_qla.ops.gated_delta_rule.chunk as chunk_backend
+    from flash_qla.ops.gated_delta_rule.chunk.blackwell import (
+        correct_initial_states,
+        get_warmup_chunks,
+    )
+    from flash_qla.utils import l2norm
+    from ref_gdr import chunk_gated_delta_rule_bwd as chunk_gated_delta_rule_bwd_ref
+    from ref_gdr import chunk_gated_delta_rule_fwd as chunk_gated_delta_rule_fwd_ref
+
+    torch.manual_seed(42)
+    batch_size, num_tokens, num_k_heads, num_v_heads = 1, 512, 4, 12
+    head_dim = 128
+    dtype = torch.bfloat16
+    device = torch.device("cuda")
+
+    q = l2norm(
+        torch.randn(
+            batch_size, num_tokens, num_k_heads, head_dim, device=device, dtype=dtype
+        )
+    )
+    k = l2norm(
+        torch.randn(
+            batch_size, num_tokens, num_k_heads, head_dim, device=device, dtype=dtype
+        )
+    )
+    v = torch.randn(
+        batch_size, num_tokens, num_v_heads, head_dim, device=device, dtype=dtype
+    )
+    g = (
+        torch.nn.functional.logsigmoid(
+            torch.randn(
+                batch_size, num_tokens, num_v_heads, device=device, dtype=torch.float32
+            )
+        )
+        / 16
+    )
+    beta = torch.randn(
+        batch_size, num_tokens, num_v_heads, device=device, dtype=torch.float32
+    ).sigmoid()
+    do = torch.randn_like(v)
+    scale = head_dim**-0.5
+
+    assert chunk_backend._chunk_backend == "blackwell"
+    assert ".blackwell." in chunk_backend.fused_gdr_fwd.__module__
+    print(
+        f"blackwell_gdr_backend backend={chunk_backend._chunk_backend} "
+        f"fwd_module={chunk_backend.fused_gdr_fwd.__module__}",
+        flush=True,
+    )
+
+    original_backend = chunk_backend._chunk_backend
+    chunk_backend._chunk_backend = "hopper"
+    try:
+        with pytest.raises(RuntimeError, match="SM90/Hopper TileLang target"):
+            chunk_gated_delta_rule_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                auto_cp=False,
+            )
+    finally:
+        chunk_backend._chunk_backend = original_backend
+
+    cp_cu_seqlens = torch.tensor([0, 256, 512], device=device, dtype=torch.int32)
+    ht_mask = torch.tensor([False, True], device=device)
+    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
+        get_warmup_chunks(
+            g=g,
+            cu_seqlens=cp_cu_seqlens,
+            ht_mask=ht_mask,
+            chunk_size=64,
+            threshold=-10.0,
+        )
+    with pytest.raises(RuntimeError, match="auto_cp is not supported"):
+        correct_initial_states(
+            raw_h0=torch.empty(1, num_v_heads, head_dim, head_dim, device=device),
+            ht_buffer=torch.empty(2, num_v_heads, head_dim, head_dim, device=device),
+            mt_buffer=torch.empty(2, num_v_heads, device=device),
+            fallback_mask=torch.empty(2, num_v_heads, dtype=torch.bool, device=device),
+            seq_map_r2c=torch.tensor([0, 2], device=device, dtype=torch.int32),
+        )
+
+    with pytest.raises(RuntimeError, match="auto_cp=True is not supported on SM100"):
+        chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            auto_cp=True,
+        )
+
+    g_ref, o_ref, A_ref, _, _ = chunk_gated_delta_rule_fwd_ref(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        g=g.float(),
+        beta=beta.float(),
+        scale=scale,
+    )
+    g_qla, A_qla, o_qla, _, _ = chunk_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        output_final_state=True,
+        output_h=False,
+        auto_cp=None,
+    )
+
+    _assert_close("g", g_ref, g_qla.float(), ratio=0.002)
+    _assert_close("o", o_ref, o_qla.float(), ratio=0.02)
+
+    dq_ref, dk_ref, dv_ref, db_ref, dg_ref, _ = chunk_gated_delta_rule_bwd_ref(
+        q.float(),
+        k.float(),
+        v.float(),
+        g_ref,
+        beta.float(),
+        A_ref,
+        scale,
+        None,
+        do.float(),
+        None,
+        None,
+    )
+    dq_qla, dk_qla, dv_qla, db_qla, dg_qla, _ = chunk_gated_delta_rule_bwd(
+        q,
+        k,
+        v,
+        g_qla,
+        beta,
+        A_qla,
+        do,
+        None,
+        scale,
+        None,
+        None,
+    )
+
+    _assert_close("dq", dq_ref, dq_qla.float(), ratio=0.03)
+    _assert_close("dk", dk_ref, dk_qla.float(), ratio=0.03)
+    _assert_close("dv", dv_ref, dv_qla.float(), ratio=0.03)
+    _assert_close("dbeta", db_ref, db_qla.float(), ratio=0.03)
+    _assert_close("dg", dg_ref, dg_qla.float(), ratio=0.03)


### PR DESCRIPTION
## Summary
- Add a dedicated `blackwell/` GDN chunk backend and route TileLang target `10.0` there; `hopper/` remains the sm90 path.
- Keep public `auto_cp=None` behavior but disable auto-CP by default on SM100 and fail fast for explicit `auto_cp=True`; no fallback path is used.
- Fix the Blackwell fused backward/KKT kernels in the SM100 backend, add runtime backend/device agreement checks, and add a focused B200 pytest covering backend contract plus full-chunk, partial-initial-state, and varlen-partial precision cases.
- Require `tilelang==0.1.10`, matching the B200-validated lowering behavior.

## Before
- Upstream base could not run the public path on B200 because the import/dispatch gate only admitted sm90.
- If the old path was forced locally for sm100, a B200/sm100 Ulysses-rank core shape failed numerically. Short shape `grad.key` was `max_abs=7.167e-2` versus torch floor `6.137e-4` (`116.8x`), with `p99_abs=2.053e-2` versus `1.139e-4` (`180.2x`).
- The corresponding long core shape produced non-finite candidate metrics for `output`, `grad.query`, `grad.key`, `grad.value`, `grad.g`, and `grad.beta` (`max_abs=NaN`, `p99_abs=NaN`) while the torch floor stayed finite.

## Minimal B200 Test
Run on a B200/sm100 node:

```bash
python -m pytest tests/test_blackwell_gdr.py -q -s
```

After this PR, current HEAD `36a0c71` was rerun on B200/sm100 on 2026-06-15 and passed in `13.16s`:

```text
torch: 2.11.0+cu130
gpu0: NVIDIA B200 sm100
blackwell_gdr_backend backend=blackwell fwd_module=flash_qla.ops.gated_delta_rule.chunk.blackwell.fused_fwd
blackwell_gdr_metric name=full_chunks.run2.dg max_abs=0.0356788 limit=0.0898049 ref_max=1.7941
blackwell_gdr_metric name=partial_initial_state.run2.dq max_abs=0.0156019 limit=0.172216 ref_max=5.7372
blackwell_gdr_metric name=partial_initial_state.run2.dk max_abs=0.0232172 limit=0.154547 ref_max=5.14822
blackwell_gdr_metric name=partial_initial_state.run2.dg max_abs=0.201498 limit=0.257168 ref_max=5.14136
blackwell_gdr_metric name=partial_initial_state.run2.dh0 max_abs=0.000236459 limit=0.00353078 ref_max=0.114359
blackwell_gdr_metric name=varlen_partial.run2.dg max_abs=0.0513951 limit=0.0911224 ref_max=1.82045
4 passed, 14 warnings in 13.16s
```

The same test asserts that the Blackwell backend is selected for TileLang target `10.0` and that the Blackwell auto-CP helper exports fail fast with the intended `RuntimeError`, rather than falling through to Hopper or a signature `TypeError`.

## Manual B200 Topology Smoke
A manual Qwen-style TP4/CP4 mock-data harness was rerun on B200/sm100 with current FLA and FlashQLA branches. Each row compares the candidate backend against a PyTorch backend reference and times forward+backward throughput after warmup.

| profile | case | precision | tok/s | previous tok/s | delta |
|---|---:|---:|---:|---:|---:|
| `fla_separate` | short | PASS | 495,927 | 505,005 | -1.80% |
| `fla_separate` | long | PASS | 9,829,483 | 9,776,240 | +0.54% |
| `ulysses_fla` | short | PASS | 204,256 | 197,902 | +3.21% |
| `ulysses_fla` | long | PASS | 7,866,287 | 7,722,419 | +1.86% |
| `ulysses_flash_qla` | short | PASS | 147,391 | 145,081 | +1.59% |
| `ulysses_flash_qla` | long | PASS | 1,151,204 | 1,147,544 | +0.32% |

A second manual B200/sm100 smoke used a Qwen3.5-27B-like TP2/CP4 128k layout. The TP2 shard has `8 key / 24 value` heads; Ulysses CP4 gives each rank a `2 key / 6 value` full-sequence core. This run compared the Ulysses path against a real balanced CP-local wrapper baseline rather than a core-only timing.

| profile | case | precision | tok/s | vs real `fla_separate_cp` |
|---|---:|---:|---:|---:|
| `fla_separate_cp` | 128k | PASS | 1,778,013 | 1.00x |
| `ulysses_fla` | 128k | PASS | 4,059,666 | 2.28x |
| `ulysses_flash_qla` | 128k | PASS | 795,284 | 0.45x |

The FlashQLA SM100 path is now numerically viable in the Ulysses-rank shape, but it is still throughput-limited. In the TP2/CP4 128k real-wrapper smoke it is slower than both `ulysses_fla` and the balanced CP-local FLA baseline. The likely bottleneck is the current small-head Blackwell path/padding/launch overhead; a follow-up performance PR should add a native SM100 path for this small-head topology or repair SM100 auto-CP.

## Other Validation
- `ruff check --no-cache tests/test_blackwell_gdr.py tests/ref_gdr.py README.md`: PASS.
- `ruff format --check tests/test_blackwell_gdr.py tests/ref_gdr.py`: PASS.
- GitHub checks: none are currently reported on the `blackwell-sm100-gdn-fused-bwd` branch.
