### PR TITLE
Fix gated delta rule gradients

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -4,30 +4,116 @@
 import torch
 import tilelang
 
-from flash_qla.utils import l2norm_fwd, l2norm_bwd, prepare_chunk_offsets
-from flash_qla.ops.utils import chunk_local_cumsum, group_reduce_vector
+from flash_qla.utils import l2norm_fwd, l2norm_bwd
+from flash_qla.ops.utils import chunk_local_cumsum
 
 if tilelang.contrib.nvcc.get_target_compute_version() == "9.0":
-    from .hopper import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
-    from .hopper import get_warmup_chunks, get_warmup_chunks_bidi, correct_initial_states, correct_terminal_states
-    from .hopper.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
+    from .hopper import fused_gdr_fwd, kkt_solve
+    BACKWARD_SUPPORTED = True
     CHUNK_SIZE = 64
 elif tilelang.contrib.nvcc.get_target_compute_version() == "10.0":
-    from .blackwell import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
-    from .blackwell import get_warmup_chunks, get_warmup_chunks_bidi, correct_initial_states, correct_terminal_states
-    from .blackwell.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
+    from .blackwell import fused_gdr_fwd, kkt_solve
+    BACKWARD_SUPPORTED = True
     CHUNK_SIZE = 64
 elif tilelang.contrib.nvcc.get_target_compute_version() == "12.0":
-    from .blackwell_sm120 import fused_gdr_fwd, fused_gdr_h, kkt_solve
-    from .blackwell_sm120 import get_warmup_chunks, get_warmup_chunks_bidi, correct_initial_states, correct_terminal_states
-    fused_gdr_bwd = None
-    fused_gdr_dh = None
+    from .blackwell_sm120 import fused_gdr_fwd, kkt_solve
+    BACKWARD_SUPPORTED = False
     CHUNK_SIZE = 32
 else:
     raise ValueError("FlashQLA now support sm90 and sm100 only.")
-from .cp_context import intra_card_cp_preprocess, intra_card_cp_preprocess_bwd, _calc_cp_seqs, _create_cu_seqlens
+from .cp_context import intra_card_cp_preprocess
 
 from flash_qla.utils import input_guard
+
+
+def _zero_sequence_start_grad(
+    dg: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None,
+):
+    if cu_seqlens is None:
+        dg[:, 0] = 0
+    else:
+        dg[0, cu_seqlens[:-1].long()] = 0
+
+
+def _zero_padded_token_grads(
+    cu_seqlens: torch.LongTensor | None,
+    *grads: torch.Tensor,
+):
+    if cu_seqlens is not None:
+        # FLA's varlen kernels leave the token tail unwritten.
+        num_valid_tokens = int(cu_seqlens[-1].item())
+        for grad in grads:
+            grad[:, num_valid_tokens:] = 0
+
+
+def _require_backward_support():
+    if not BACKWARD_SUPPORTED:
+        raise NotImplementedError(
+            "Backward pass is not implemented for SM120 (Blackwell)."
+            " Only forward pass is supported on this architecture."
+        )
+
+
+def _fla_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor | None,
+    state_v_first: bool,
+):
+    """Run FLA's stable backward against FlashQLA forward activations."""
+    _require_backward_support()
+
+    from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_bwd
+    from fla.ops.gated_delta_rule.chunk_fwd import chunk_gated_delta_rule_fwd_intra
+    from fla.ops.utils import prepare_chunk_indices
+    from fla.ops.utils.constant import RCP_LN2
+
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, CHUNK_SIZE)
+        if cu_seqlens is not None
+        else None
+    )
+    # FlashQLA accumulates natural-log gates; FLA kernels consume log2 gates.
+    fla_g = g * RCP_LN2
+    # FlashQLA's A is ungated, while FLA's backward expects a gated A.
+    _, _, fla_A = chunk_gated_delta_rule_fwd_intra(
+        k=k,
+        v=v,
+        g=fla_g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=CHUNK_SIZE,
+    )
+    dq, dk, dv, db, dg, dh0, _, _ = chunk_gated_delta_rule_bwd(
+        q=q,
+        k=k,
+        v=v,
+        g=fla_g,
+        beta=beta,
+        A=fla_A,
+        scale=scale,
+        initial_state=initial_state,
+        do=do,
+        dht=dht,
+        state_v_first=state_v_first,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=CHUNK_SIZE,
+    )
+    if initial_state is None:
+        dh0 = None
+        _zero_sequence_start_grad(dg, cu_seqlens)
+    _zero_padded_token_grads(cu_seqlens, dq, dk, dv, db, dg)
+    return dq, dk, dv, db, dg, dh0
 
 
 def chunk_gated_delta_rule_fwd(
@@ -104,59 +190,21 @@ def chunk_gated_delta_rule_bwd(
     auto_cp: bool = True,
     cp_cache: tuple | None = None,
 ):
-    if fused_gdr_bwd is None:
-        raise NotImplementedError(
-            "Backward pass is not implemented for SM120 (Blackwell)."
-            "Only forward pass is supported on this architecture."
-        )
-
-    batch_size, num_tokens, num_k_heads, _ = k.shape
-    _, _, H, _ = v.shape
-    chunk_size = A.shape[-1]
-
-    if auto_cp and fused_gdr_dh is not None:
-        h0, cu_seqlens_fwd, dht, cu_seqlens_bwd, seq_map_r2c, use_cp = intra_card_cp_preprocess_bwd(
-            k=k, v=v, a=A, g=g, b=beta, raw_h0=initial_state,
-            q=q, do=do, dht=dht, scale=scale,
-            raw_cu_seqlens=cu_seqlens,
-            state_v_first=state_v_first,
-            cp_cache=cp_cache,
-        )
-    else:
-        h0 = initial_state
-        cu_seqlens_fwd = cu_seqlens
-        dht = dht
-        cu_seqlens_bwd = cu_seqlens
-        seq_map_r2c = None
-        use_cp = False
-
-    h, _, _ = fused_gdr_h(
-        k=k, v=v, a=A, g=g, b=beta,
-        initial_state=h0,
-        output_final_state=False,
-        output_h=True,
-        cu_seqlens=cu_seqlens_fwd,
+    # These arguments are retained for API compatibility with the fused path.
+    del A, auto_cp, cp_cache
+    return _fla_gated_delta_rule_bwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        do=do,
+        dht=dht,
+        scale=scale if scale is not None else q.shape[-1] ** -0.5,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
         state_v_first=state_v_first,
     )
-    dq, dk, dv, dg, db, dh0 = fused_gdr_bwd(
-        q=q, k=k, v=v, a=A, g=g, b=beta,
-        do=do, dht=dht, h=h, scale=scale,
-        cu_seqlens=cu_seqlens_bwd,
-        state_v_first=state_v_first,
-    )
-
-    if use_cp:  # TODO store dh0 in fused_bwd kernel
-        dh0 = dh0[seq_map_r2c[:-1].long()] if dh0 is not None else None
-    elif initial_state is None:
-        dh0 = None
-
-    Hg, H = k.shape[-2], v.shape[-2]
-    if Hg < H:
-        dq = group_reduce_vector(dq, Hg)
-        dk = group_reduce_vector(dk, Hg)
-    assert dg.dtype == torch.float32, "dg should be fp32"
-    dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens)
-    return dq, dk, dv, db, dg, dh0
 
 
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
@@ -177,14 +225,15 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         state_v_first: bool = False,
         auto_cp: bool = True,
         use_qk_l2norm_in_kernel: bool = False,
-        enable_fwd_cp_cache: bool = True,
     ):
         q_rstd, k_rstd = None, None
         if use_qk_l2norm_in_kernel:
             q, q_rstd = l2norm_fwd(q)
             k, k_rstd = l2norm_fwd(k)
 
-        g, A, o, _, final_state, cp_cache = chunk_gated_delta_rule_fwd(
+        # The stable backward recomputes its intermediates and cannot consume
+        # the FlashQLA-specific CP cache.
+        g, _, o, _, final_state, _ = chunk_gated_delta_rule_fwd(
             q=q,
             k=k,
             v=v,
@@ -197,22 +246,14 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             state_v_first=state_v_first,
             auto_cp=auto_cp,
-            enable_fwd_cp_cache=enable_fwd_cp_cache,
+            enable_fwd_cp_cache=False,
         )
 
-        if cp_cache is not None:
-            cached_cp_h0, cached_mt, cached_fallback_bwd, cached_num_warmup_bwd = cp_cache
-            ctx.save_for_backward(
-                q, k, q_rstd, k_rstd, v, g, beta, A, initial_state, cu_seqlens,
-                cached_cp_h0, cached_mt, cached_fallback_bwd, cached_num_warmup_bwd,
-            )
-            ctx._cp_cache_count = 4
-        else:
-            ctx.save_for_backward(q, k, q_rstd, k_rstd, v, g, beta, A, initial_state, cu_seqlens)
-            ctx._cp_cache_count = 0
+        ctx.save_for_backward(
+            q, k, q_rstd, k_rstd, v, g, beta, initial_state, cu_seqlens
+        )
         ctx.scale = scale
         ctx.state_v_first = state_v_first
-        ctx.autocp = auto_cp
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         return o.to(q.dtype), final_state
 
@@ -220,29 +261,22 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
     @input_guard
     @torch.amp.custom_bwd(device_type="cuda")
     def backward(ctx, do: torch.Tensor, dht: torch.Tensor):
-        if ctx._cp_cache_count == 4:
-            q, k, q_rstd, k_rstd, v, g, beta, A, initial_state, cu_seqlens, \
-                cached_cp_h0, cached_mt, cached_fallback_bwd, cached_num_warmup_bwd = ctx.saved_tensors
-            cp_cache = (cached_cp_h0, cached_mt, cached_fallback_bwd, cached_num_warmup_bwd)
-        else:
-            q, k, q_rstd, k_rstd, v, g, beta, A, initial_state, cu_seqlens = ctx.saved_tensors
-            cp_cache = None
+        (
+            q, k, q_rstd, k_rstd, v, g, beta, initial_state, cu_seqlens
+        ) = ctx.saved_tensors
 
-        dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
+        dq, dk, dv, db, dg, dh0 = _fla_gated_delta_rule_bwd(
             q=q,
             k=k,
             v=v,
             g=g,
             beta=beta,
-            A=A,
             do=do,
             dht=dht,
             scale=ctx.scale,
             initial_state=initial_state,
             cu_seqlens=cu_seqlens,
             state_v_first=ctx.state_v_first,
-            auto_cp=ctx.autocp,
-            cp_cache=cp_cache,
         )
 
         if ctx.use_qk_l2norm_in_kernel:
@@ -256,8 +290,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             dg.to(g),
             db.to(beta),
             None,
-            dh0 if initial_state is not None else None,
-            None,
+            dh0,
             None,
             None,
             None,
@@ -319,7 +352,7 @@ def chunk_gated_delta_rule(
         auto_cp (Optional[bool]):
             Whether to enable automatic intra-card CP. Default: `True`.
         enable_fwd_cp_cache (Optional[bool]):
-            Whether to cache CP related variables during the forward pass. Default: `True`.
+            Retained for compatibility. Stable backward recomputes its state. Default: `True`.
 
     Returns:
         o (torch.Tensor):
@@ -398,7 +431,6 @@ def chunk_gated_delta_rule(
         state_v_first,
         auto_cp,
         use_qk_l2norm_in_kernel,
-        enable_fwd_cp_cache,
     )
 
     return o, final_state

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "torch>=2.8",
+        "flash-linear-attention @ "
+        "git+https://github.com/fla-org/flash-linear-attention.git@ebf3a0cff2be3e6f2b2f99820b8fe4e28855ced0",
         "tilelang==0.1.9",
         "apache-tvm-ffi==0.1.9",
     ],

--- a/tests/test_gdr_gradients.py
+++ b/tests/test_gdr_gradients.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+import pytest
+import torch
+
+from flash_qla import chunk_gated_delta_rule
+from flash_qla.utils import l2norm
+
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+HEAD_DIM = 128
+RTOL = 0.02
+
+
+def _recurrent_gated_delta_rule(q, k, v, g, beta, cu_seqlens, initial_state=None):
+    """Small, stable reference for strong-decay gradient tests."""
+    num_value_heads = v.shape[2]
+    q = q.repeat_interleave(num_value_heads // q.shape[2], dim=2)
+    k = k.repeat_interleave(num_value_heads // k.shape[2], dim=2)
+    boundaries = cu_seqlens.tolist() if cu_seqlens is not None else [0, q.shape[1]]
+    outputs = []
+    final_states = []
+    for sequence, (begin, end) in enumerate(zip(boundaries, boundaries[1:])):
+        state = (
+            initial_state[sequence]
+            if initial_state is not None
+            else q.new_zeros(num_value_heads, q.shape[-1], v.shape[-1])
+        )
+        for token in range(begin, end):
+            state = state * g[0, token, :, None, None].exp()
+            prediction = torch.einsum("hk,hkv->hv", k[0, token], state)
+            residual = beta[0, token, :, None] * (v[0, token] - prediction)
+            state = state + torch.einsum("hk,hv->hkv", k[0, token], residual)
+            outputs.append(torch.einsum("hk,hkv->hv", q[0, token], state))
+        final_states.append(state)
+    output = torch.stack(outputs).unsqueeze(0) * q.shape[-1] ** -0.5
+    return output, torch.stack(final_states)
+
+
+def _assert_relative_l2(actual, expected, name):
+    error = torch.linalg.vector_norm(actual.double() - expected.double()).item()
+    reference = torch.linalg.vector_norm(expected.double()).item()
+    assert error <= reference * RTOL, (
+        f"{name}: error={error:.6f}, reference={reference:.6f}, "
+        f"relative={error / reference:.6f} > rtol={RTOL}"
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "cu_seqlens_list",
+    [None, pytest.param([0, 47, 128], id="packed")],
+)
+def test_qwen_decay_parameter_gradients(cu_seqlens_list):
+    """Strong Qwen decay transforms need stable parameter gradients."""
+    torch.manual_seed(20260719)
+    q = l2norm(torch.randn(1, 128, 2, HEAD_DIM, device=DEVICE, dtype=DTYPE))
+    k = l2norm(torch.randn(1, 128, 2, HEAD_DIM, device=DEVICE, dtype=DTYPE))
+    v = torch.randn(1, 128, 4, HEAD_DIM, device=DEVICE, dtype=DTYPE)
+    beta = torch.randn(1, 128, 4, device=DEVICE).sigmoid()
+    gate_input = torch.randn(1, 128, 4, device=DEVICE) * 0.5
+    A_log = torch.tensor([0.5, 2.0, 8.0, 16.0], device=DEVICE).log()
+    dt_bias = torch.ones(4, device=DEVICE)
+    do = torch.randn_like(v)
+    cu_seqlens = (
+        torch.tensor(cu_seqlens_list, device=DEVICE, dtype=torch.int32)
+        if cu_seqlens_list is not None
+        else None
+    )
+
+    qla_params = [
+        tensor.detach().clone().requires_grad_(True)
+        for tensor in (gate_input, A_log, dt_bias)
+    ]
+    qla_g = -qla_params[1].exp() * torch.nn.functional.softplus(
+        qla_params[0] + qla_params[2]
+    )
+    qla_g.retain_grad()
+    qla_o, _ = chunk_gated_delta_rule(
+        q, k, v, qla_g, beta, cu_seqlens=cu_seqlens, auto_cp=True
+    )
+    (qla_o.float() * do.float()).sum().backward()
+
+    ref_params = [
+        tensor.detach().double().requires_grad_(True)
+        for tensor in (gate_input, A_log, dt_bias)
+    ]
+    ref_g = -ref_params[1].exp() * torch.nn.functional.softplus(
+        ref_params[0] + ref_params[2]
+    )
+    ref_o, _ = _recurrent_gated_delta_rule(
+        q.double(), k.double(), v.double(), ref_g, beta.double(), cu_seqlens
+    )
+    (ref_o * do.double()).sum().backward()
+
+    for name, actual, expected in zip(
+        ("gate_input", "A_log", "dt_bias"), qla_params, ref_params, strict=True
+    ):
+        _assert_relative_l2(actual.grad, expected.grad, name)
+
+    starts = (
+        cu_seqlens[:-1] if cu_seqlens is not None else torch.tensor([0], device=DEVICE)
+    )
+    assert torch.count_nonzero(qla_g.grad[0, starts]).item() == 0
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "cu_seqlens_list,state_v_first,use_qk_l2norm_in_kernel",
+    [
+        pytest.param(None, False, False, id="fixed-kv"),
+        pytest.param([0, 47, 117], True, True, id="padded-vk-l2norm"),
+    ],
+)
+def test_public_initial_and_final_state_gradients(
+    cu_seqlens_list, state_v_first, use_qk_l2norm_in_kernel
+):
+    """The public API must propagate output and final-state gradients."""
+    torch.manual_seed(20260720)
+    num_sequences = 1 if cu_seqlens_list is None else len(cu_seqlens_list) - 1
+    q = torch.randn(1, 128, 2, HEAD_DIM, device=DEVICE, dtype=DTYPE)
+    k = torch.randn_like(q)
+    if not use_qk_l2norm_in_kernel:
+        q, k = l2norm(q), l2norm(k)
+    v = torch.randn(1, 128, 4, HEAD_DIM, device=DEVICE, dtype=DTYPE)
+    g = torch.nn.functional.logsigmoid(torch.randn(1, 128, 4, device=DEVICE)) / 16
+    beta = torch.randn(1, 128, 4, device=DEVICE).sigmoid()
+    h0 = torch.randn(num_sequences, 4, HEAD_DIM, HEAD_DIM, device=DEVICE)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0) / 8
+    cu_seqlens = (
+        torch.tensor(cu_seqlens_list, device=DEVICE, dtype=torch.int32)
+        if cu_seqlens_list is not None
+        else None
+    )
+
+    qla_inputs = [
+        tensor.detach().clone().requires_grad_(True) for tensor in (q, k, v, g, beta)
+    ]
+    qla_h0 = h0.transpose(-1, -2) if state_v_first else h0
+    qla_h0 = qla_h0.contiguous().detach().requires_grad_(True)
+    qla_dht = dht.transpose(-1, -2) if state_v_first else dht
+    qla_o, qla_ht = chunk_gated_delta_rule(
+        *qla_inputs,
+        initial_state=qla_h0,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        state_v_first=state_v_first,
+        auto_cp=True,
+    )
+    num_valid_tokens = 128 if cu_seqlens is None else int(cu_seqlens[-1].item())
+    (
+        (qla_o[:, :num_valid_tokens].float() * do[:, :num_valid_tokens].float()).sum()
+        + (qla_ht * qla_dht).sum()
+    ).backward()
+
+    ref_inputs = [
+        tensor.detach().double().requires_grad_(True) for tensor in (q, k, v, g, beta)
+    ]
+    ref_h0 = h0.detach().double().requires_grad_(True)
+    ref_q, ref_k, ref_v, ref_g, ref_beta = ref_inputs
+    if use_qk_l2norm_in_kernel:
+        ref_q = torch.nn.functional.normalize(ref_q, dim=-1)
+        ref_k = torch.nn.functional.normalize(ref_k, dim=-1)
+    ref_o, ref_ht = _recurrent_gated_delta_rule(
+        ref_q, ref_k, ref_v, ref_g, ref_beta, cu_seqlens, ref_h0
+    )
+    (
+        (ref_o * do[:, :num_valid_tokens].double()).sum()
+        + (ref_ht * dht.double()).sum()
+    ).backward()
+
+    for name, actual, expected in zip(
+        ("q", "k", "v", "g", "beta"), qla_inputs, ref_inputs, strict=True
+    ):
+        _assert_relative_l2(actual.grad, expected.grad, name)
+    qla_dh0 = qla_h0.grad.transpose(-1, -2) if state_v_first else qla_h0.grad
+    _assert_relative_l2(qla_dh0, ref_h0.grad, "initial_state")

--- a/tests/test_gdr_unit.py
+++ b/tests/test_gdr_unit.py
@@ -376,6 +376,10 @@ def test_bwd(
     _assert_relative(dv_qla, dv_ref, "dv_qla")
     _assert_relative(db_qla, db_ref, "db_qla")
     _assert_relative(dg_qla, dg_ref, "dg_qla")
+    if cu_seqlens is not None:
+        num_valid_tokens = int(cu_seqlens[-1].item())
+        for grad in (dq_qla, dk_qla, dv_qla, db_qla, dg_qla):
+            assert torch.count_nonzero(grad[:, num_valid_tokens:]).item() == 0
     if dht_ref is not None:
         dh0_qla_cmp = (
             dh0_qla.transpose(-1, -2)
@@ -577,18 +581,19 @@ def test_fwd_auto_cp(
 
 @pytest.mark.gpu
 @pytest.mark.parametrize(
-    "batch_size, num_tokens, num_k_heads, num_v_heads, varlen, cu_seqlens_list",
+    "batch_size, num_tokens, num_k_heads, num_v_heads, varlen, cu_seqlens_list, use_h0",
     [
-        pytest.param(1, 16384, 4, 4, False, None, id="long-fixed"),
+        pytest.param(1, 16384, 4, 4, False, None, True, id="long-fixed"),
         pytest.param(1, 16384, 4, 4, True,
-                     [0, 4096, 8192, 12288, 16384],
+                     [0, 4096, 8192, 12288, 16384], True,
                      id="long-varlen"),
+        pytest.param(1, 16384, 4, 4, False, None, False, id="long-no-h0"),
     ],
 )
 @pytest.mark.parametrize("state_v_first", [False, True], ids=["kv", "vk"])
 def test_bwd_auto_cp(
     batch_size, num_tokens, num_k_heads, num_v_heads,
-    varlen, cu_seqlens_list, state_v_first,
+    varlen, cu_seqlens_list, state_v_first, use_h0,
 ):
     """Backward: auto_cp=True and auto_cp=False should match reference."""
     (
@@ -597,7 +602,7 @@ def test_bwd_auto_cp(
         cu_seqlens, scale,
     ) = _make_inputs(
         batch_size, num_tokens, num_k_heads, num_v_heads,
-        varlen, cu_seqlens_list, use_h0=True, state_v_first=state_v_first,
+        varlen, cu_seqlens_list, use_h0=use_h0, state_v_first=state_v_first,
     )
 
     # Run fwd for both cp modes
@@ -659,6 +664,16 @@ def test_bwd_auto_cp(
         if dht_ref is not None:
             dh0_cmp = dh0.transpose(-1, -2) if state_v_first else dh0
             _assert_relative(dh0_cmp, dh0_ref, f"dh0_{prefix}")
+        else:
+            assert dh0 is None
+
+        if h0_ref is None:
+            starts = (
+                cu_seqlens[:-1]
+                if cu_seqlens is not None
+                else torch.tensor([0], device=dg.device)
+            )
+            assert torch.count_nonzero(dg[0, starts]).item() == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep the fused FlashQLA forward while using the pinned FLA stable multi-kernel backward
- make the exported backward and public autograd path share one gradient implementation
- return no synthetic initial-state gradient and zero true sequence-start gate gradients
- zero every gradient in the packed-token padding tail
- cover strong Qwen decay, initial/final states, layouts, GVA, normalization, and padding against FP64 references

## Why

The fused backward gate-gradient cancellation becomes inaccurate for strong Qwen decay values. It can substantially corrupt A_log and dt_bias gradients even while forward outputs look correct. FLA commit ebf3a0c provides the stable backward used here; it is pinned because the required 0.5.2 code is not yet published and released 0.5.1 fails on SM100.

The broad audit also found that the FLA low-level varlen kernels leave gradients after cu_seqlens[-1] unwritten. The shared adapter now makes that padding tail exactly zero.

## Validation

- B200, upstream pins: all 24 core backward configurations covered across fixed/varlen/padded inputs, GVA, both state layouts, and with/without initial state
- B200, production pins: 10 focused cases passed, including six long real auto-CP cases; all four padded backward state/layout cases and both public-state cases passed
- H100, upstream and production pins: fixed/packed strong-decay and public initial/final-state gradient cases passed
- FP64 recurrent oracle: q/k/v/g/beta/initial-state gradients, Qwen gate_input/A_log/dt_bias gradients, final-state loss, and fused q/k normalization are within 2% relative L2
- exact zero checks: true sequence-start gate gradients without h0 and every padded-token gradient
- static signature checks, Ruff, py_compile, and thermo-nuclear maintainability review passed
- B200 T=16384 benchmark: 2.23 ms stable path vs 2.74 ms old fused path