### PR TITLE
Add SM103 (Blackwell B300) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Key features:
 
 Requirements:
 
-- SM90 or SM100
+- SM90, SM100 or SM103
 - CUDA 12.8 or above
 - PyTorch 2.8 or above
 

--- a/flash_qla/ops/gated_delta_rule/chunk/__init__.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/__init__.py
@@ -12,7 +12,7 @@ if tilelang.contrib.nvcc.get_target_compute_version() == "9.0":
     from .hopper import get_warmup_chunks, get_warmup_chunks_bidi, correct_initial_states, correct_terminal_states
     from .hopper.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
     CHUNK_SIZE = 64
-elif tilelang.contrib.nvcc.get_target_compute_version() == "10.0":
+elif tilelang.contrib.nvcc.get_target_compute_version() in ["10.0", "10.3"]:
     from .blackwell import fused_gdr_fwd, fused_gdr_bwd, fused_gdr_h, kkt_solve
     from .blackwell import get_warmup_chunks, get_warmup_chunks_bidi, correct_initial_states, correct_terminal_states
     from .blackwell.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
@@ -24,7 +24,7 @@ elif tilelang.contrib.nvcc.get_target_compute_version() == "12.0":
     fused_gdr_dh = None
     CHUNK_SIZE = 32
 else:
-    raise ValueError("FlashQLA now support sm90 and sm100 only.")
+    raise ValueError(f"FlashQLA now support sm90, sm100 and sm103 only. Found compute version: {tilelang.contrib.nvcc.get_target_compute_version()}")
 from .cp_context import intra_card_cp_preprocess, intra_card_cp_preprocess_bwd, _calc_cp_seqs, _create_cu_seqlens
 
 from flash_qla.utils import input_guard

--- a/flash_qla/ops/gated_delta_rule/chunk/cp_context.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/cp_context.py
@@ -17,12 +17,16 @@ elif tilelang.contrib.nvcc.get_target_compute_version() == "10.0":
     from .blackwell import get_warmup_chunks, get_warmup_chunks_bidi, fused_gdr_h, correct_initial_states, correct_terminal_states
     from .blackwell.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
     ARCH = "SM100"
+elif tilelang.contrib.nvcc.get_target_compute_version() == "10.3":
+    from .blackwell import get_warmup_chunks, get_warmup_chunks_bidi, fused_gdr_h, correct_initial_states, correct_terminal_states
+    from .blackwell.cp_bwd import fused_gdr_dh_ws as fused_gdr_dh
+    ARCH = "SM103"
 elif tilelang.contrib.nvcc.get_target_compute_version() == "12.0":
     from .blackwell_sm120 import get_warmup_chunks, get_warmup_chunks_bidi, fused_gdr_h, correct_initial_states, correct_terminal_states
     fused_gdr_dh = None
     ARCH = "SM120"
 else:
-    raise ValueError("FlashQLA now support sm90 and sm100 only.")
+    raise ValueError(f"FlashQLA now support sm90, sm100 and sm103 only. Found compute version: {tilelang.contrib.nvcc.get_target_compute_version()}")
 
 
 MULTI_PROCESSOR_COUNT = torch.cuda.get_device_properties().multi_processor_count
@@ -103,7 +107,7 @@ def _calc_cp_seqs(
 
     if ARCH == "SM90" or ARCH == "SM120":
         use_cp = Be * H <= 40 or (Be * H <= 56 and max(num_chunks) >= 128)
-    elif ARCH == "SM100":
+    elif ARCH in ["SM100", "SM103"]:
         # SM100 uses separate thresholds for fwd and bwd:
         # - bwd kernel does more work per chunk (higher arithmetic intensity), so GPU
         #   under-utilization appears at fewer chunks (>=64 vs >=256 for fwd). It also
@@ -119,7 +123,7 @@ def _calc_cp_seqs(
                 Be * H <= 32 and max(num_chunks) >= 192
             )
     else:
-        raise ValueError("FlashQLA now support sm90 and sm100 only.")
+        raise ValueError(f"FlashQLA now support sm90, sm100 and sm103 only. Found compute version: {tilelang.contrib.nvcc.get_target_compute_version()}")
 
     if use_cp:
         cp_cu_seqlens = torch.tensor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ if GPU_AVAILABLE:
             ARCH = "SM90"
         elif _cv == "10.0":
             ARCH = "SM100"
+        elif _cv == "10.3":
+            ARCH = "SM103"
         elif _cv == "12.0":
             ARCH = "SM120"
     except Exception:
@@ -29,7 +31,7 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.skip(reason="CUDA GPU not available"))
         if "hopper" in item.keywords and ARCH != "SM90":
             item.add_marker(pytest.mark.skip(reason="Hopper (SM90) GPU required"))
-        if "blackwell" in item.keywords and ARCH != "SM100":
-            item.add_marker(pytest.mark.skip(reason="Blackwell (SM100) GPU required"))
+        if "blackwell" in item.keywords and ARCH not in ["SM100", "SM103"]:
+            item.add_marker(pytest.mark.skip(reason="Blackwell (SM100 or SM103) GPU required"))
         if "sm120" in item.keywords and ARCH != "SM120":
             item.add_marker(pytest.mark.skip(reason="Blackwell SM120 GPU required"))

--- a/tests/test_sm120_backward_disabled.py
+++ b/tests/test_sm120_backward_disabled.py
@@ -220,7 +220,7 @@ def test_cp_preprocess_bwd_raises_not_implemented():
 def test_bwd_works_on_non_sm120(state_v_first):
     """Sanity check: backward must *not* raise on supported architectures."""
     if tilelang.contrib.nvcc.get_target_compute_version() == "12.0":
-        pytest.skip("Backward is disabled on SM120 — this test only runs on SM90/SM100")
+        pytest.skip("Backward is disabled on SM120 — this test only runs on SM90/SM100/SM103")
     q, k, v, g, beta, do, h0, dht, scale = _make_inputs(
         use_h0=True, state_v_first=state_v_first,
     )


### PR DESCRIPTION
### Summary

Simply removes the gates from `flash_qla/ops/gated_delta_rule/chunk/__init__.py` & `flash_qla/ops/gated_delta_rule/chunk/cp_context.py` to allow for SM103 (B300). 

This solves issue #27, I've confirmed this by running on a DGX B300 (AWS `p6-b300.48xlarge`).

I've included both the output of `nvidia-smi` as well as the test results including some warnings.


### Test Results
<details><summary>Output of <code>nvidia-smi</code></summary>

~~~
Fri Jul 24 13:44:49 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA B300 SXM6 AC            On  |   00000000:58:00.0 Off |                    0 |
| N/A   36C    P0            184W / 1100W |      19MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA B300 SXM6 AC            On  |   00000000:67:00.0 Off |                    0 |
| N/A   36C    P0            184W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA B300 SXM6 AC            On  |   00000000:76:00.0 Off |                    0 |
| N/A   36C    P0            180W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA B300 SXM6 AC            On  |   00000000:85:00.0 Off |                    0 |
| N/A   37C    P0            182W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA B300 SXM6 AC            On  |   00000000:94:00.0 Off |                    0 |
| N/A   52C    P0            191W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA B300 SXM6 AC            On  |   00000000:A3:00.0 Off |                    0 |
| N/A   38C    P0            183W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA B300 SXM6 AC            On  |   00000000:B2:00.0 Off |                    0 |
| N/A   36C    P0            182W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA B300 SXM6 AC            On  |   00000000:C1:00.0 Off |                    0 |
| N/A   37C    P0            183W / 1100W |      18MiB / 275040MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
~~~

</details>

<details><summary>Test results: 120/120 PASSED</summary>

~~~ shell
================================================ test session starts ================================================
platform linux -- Python 3.13.0, pytest-9.1.1, pluggy-1.6.0 -- /home/hayden/projects/FlashQLA/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/hayden/projects/FlashQLA
configfile: pytest.ini
collected 120 items

tests/test_gdr_unit.py::test_fwd[no_h0-kv-B1-T4096-H4] PASSED                                                 [  0%]
tests/test_gdr_unit.py::test_fwd[no_h0-kv-B1-T4096-H8G2] PASSED                                               [  1%]
tests/test_gdr_unit.py::test_fwd[no_h0-kv-B1-T4096-H16G4] PASSED                                              [  2%]
tests/test_gdr_unit.py::test_fwd[no_h0-kv-B3-T4096-H4-varlen] PASSED                                          [  3%]
tests/test_gdr_unit.py::test_fwd[no_h0-kv-B1-T4096-H32G16-varlen] PASSED                                      [  4%]
tests/test_gdr_unit.py::test_fwd[no_h0-kv-B1-T4096-H64G16-padding] PASSED                                     [  5%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B1-T4096-H4] PASSED                                                 [  5%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B1-T4096-H8G2] PASSED                                               [  6%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B1-T4096-H16G4] PASSED                                              [  7%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B3-T4096-H4-varlen] PASSED                                          [  8%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B1-T4096-H32G16-varlen] PASSED                                      [  9%]
tests/test_gdr_unit.py::test_fwd[no_h0-vk-B1-T4096-H64G16-padding] PASSED                                     [ 10%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B1-T4096-H4] PASSED                                                    [ 10%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B1-T4096-H8G2] PASSED                                                  [ 11%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B1-T4096-H16G4] PASSED                                                 [ 12%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B3-T4096-H4-varlen] PASSED                                             [ 13%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B1-T4096-H32G16-varlen] PASSED                                         [ 14%]
tests/test_gdr_unit.py::test_fwd[h0-kv-B1-T4096-H64G16-padding] PASSED                                        [ 15%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B1-T4096-H4] PASSED                                                    [ 15%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B1-T4096-H8G2] PASSED                                                  [ 16%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B1-T4096-H16G4] PASSED                                                 [ 17%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B3-T4096-H4-varlen] PASSED                                             [ 18%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B1-T4096-H32G16-varlen] PASSED                                         [ 19%]
tests/test_gdr_unit.py::test_fwd[h0-vk-B1-T4096-H64G16-padding] PASSED                                        [ 20%]
tests/test_gdr_unit.py::test_fwd_extended[dev-H4] PASSED                                                      [ 20%]
tests/test_gdr_unit.py::test_fwd_extended[dev-H8] PASSED                                                      [ 21%]
tests/test_gdr_unit.py::test_fwd_extended[dev-H16] PASSED                                                     [ 22%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B11-T33] PASSED                                              [ 23%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B7-T4321] PASSED                                             [ 24%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B3-T16789-vl] PASSED                                         [ 25%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B5-T8192-vl] PASSED                                          [ 25%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B10-T1024-vl] PASSED                                         [ 26%]
tests/test_gdr_unit.py::test_fwd_extended[varlen-B20-T512-vl] PASSED                                          [ 27%]
tests/test_gdr_unit.py::test_fwd_extended[prod-uniform-4k] PASSED                                             [ 28%]
tests/test_gdr_unit.py::test_fwd_extended[prod-mixed-segs] PASSED                                             [ 29%]
tests/test_gdr_unit.py::test_fwd_extended[prod-uniform-2k] PASSED                                             [ 30%]
tests/test_gdr_unit.py::test_fwd_extended[prod-mixed-large] PASSED                                            [ 30%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B1-T4096-H4] PASSED                                                 [ 31%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B1-T4096-H8G2] PASSED                                               [ 32%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B1-T4096-H16G4] PASSED                                              [ 33%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B3-T4096-H4-varlen] PASSED                                          [ 34%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B1-T4096-H32G16-varlen] PASSED                                      [ 35%]
tests/test_gdr_unit.py::test_bwd[no_h0-kv-B1-T4096-H64G16-padding] PASSED                                     [ 35%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B1-T4096-H4] PASSED                                                 [ 36%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B1-T4096-H8G2] PASSED                                               [ 37%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B1-T4096-H16G4] PASSED                                              [ 38%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B3-T4096-H4-varlen] PASSED                                          [ 39%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B1-T4096-H32G16-varlen] PASSED                                      [ 40%]
tests/test_gdr_unit.py::test_bwd[no_h0-vk-B1-T4096-H64G16-padding] PASSED                                     [ 40%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B1-T4096-H4] PASSED                                                    [ 41%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B1-T4096-H8G2] PASSED                                                  [ 42%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B1-T4096-H16G4] PASSED                                                 [ 43%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B3-T4096-H4-varlen] PASSED                                             [ 44%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B1-T4096-H32G16-varlen] PASSED                                         [ 45%]
tests/test_gdr_unit.py::test_bwd[h0-kv-B1-T4096-H64G16-padding] PASSED                                        [ 45%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B1-T4096-H4] PASSED                                                    [ 46%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B1-T4096-H8G2] PASSED                                                  [ 47%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B1-T4096-H16G4] PASSED                                                 [ 48%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B3-T4096-H4-varlen] PASSED                                             [ 49%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B1-T4096-H32G16-varlen] PASSED                                         [ 50%]
tests/test_gdr_unit.py::test_bwd[h0-vk-B1-T4096-H64G16-padding] PASSED                                        [ 50%]
tests/test_gdr_unit.py::test_bwd_extended[dev-H4] PASSED                                                      [ 51%]
tests/test_gdr_unit.py::test_bwd_extended[dev-H8] PASSED                                                      [ 52%]
tests/test_gdr_unit.py::test_bwd_extended[dev-H16] PASSED                                                     [ 53%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B11-T33] PASSED                                              [ 54%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B7-T4321] PASSED                                             [ 55%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B3-T16789-vl] PASSED                                         [ 55%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B5-T8192-vl] PASSED                                          [ 56%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B10-T1024-vl] PASSED                                         [ 57%]
tests/test_gdr_unit.py::test_bwd_extended[varlen-B20-T512-vl] PASSED                                          [ 58%]
tests/test_gdr_unit.py::test_bwd_extended[prod-uniform-4k] PASSED                                             [ 59%]
tests/test_gdr_unit.py::test_bwd_extended[prod-mixed-segs] PASSED                                             [ 60%]
tests/test_gdr_unit.py::test_bwd_extended[prod-uniform-2k] PASSED                                             [ 60%]
tests/test_gdr_unit.py::test_bwd_extended[prod-mixed-large] PASSED                                            [ 61%]
tests/test_gdr_unit.py::test_fwd_deterministic[fixed-H8G2] PASSED                                             [ 62%]
tests/test_gdr_unit.py::test_fwd_deterministic[varlen-H4] PASSED                                              [ 63%]
tests/test_gdr_unit.py::test_fwd_deterministic[varlen-H4G2] PASSED                                            [ 64%]
tests/test_gdr_unit.py::test_bwd_deterministic[fixed-H8G2] PASSED                                             [ 65%]
tests/test_gdr_unit.py::test_bwd_deterministic[varlen-H4] PASSED                                              [ 65%]
tests/test_gdr_unit.py::test_bwd_deterministic[varlen-H4G2] PASSED                                            [ 66%]
tests/test_gdr_unit.py::test_fwd_auto_cp[kv-long-fixed] PASSED                                                [ 67%]
tests/test_gdr_unit.py::test_fwd_auto_cp[kv-long-varlen] PASSED                                               [ 68%]
tests/test_gdr_unit.py::test_fwd_auto_cp[vk-long-fixed] PASSED                                                [ 69%]
tests/test_gdr_unit.py::test_fwd_auto_cp[vk-long-varlen] PASSED                                               [ 70%]
tests/test_gdr_unit.py::test_bwd_auto_cp[kv-long-fixed] PASSED                                                [ 70%]
tests/test_gdr_unit.py::test_bwd_auto_cp[kv-long-varlen] PASSED                                               [ 71%]
tests/test_gdr_unit.py::test_bwd_auto_cp[vk-long-fixed] PASSED                                                [ 72%]
tests/test_gdr_unit.py::test_bwd_auto_cp[vk-long-varlen] PASSED                                               [ 73%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-kv-cp-cache-H4] PASSED                                        [ 74%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-kv-cp-cache-H8] PASSED                                        [ 75%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-kv-cp-cache-H16] PASSED                                       [ 75%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-vk-cp-cache-H4] PASSED                                        [ 76%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-vk-cp-cache-H8] PASSED                                        [ 77%]
tests/test_gdr_unit.py::test_fwd_cp_cache[no_h0-vk-cp-cache-H16] PASSED                                       [ 78%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-kv-cp-cache-H4] PASSED                                           [ 79%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-kv-cp-cache-H8] PASSED                                           [ 80%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-kv-cp-cache-H16] PASSED                                          [ 80%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-vk-cp-cache-H4] PASSED                                           [ 81%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-vk-cp-cache-H8] PASSED                                           [ 82%]
tests/test_gdr_unit.py::test_fwd_cp_cache[h0-vk-cp-cache-H16] PASSED                                          [ 83%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-kv-cp-cache-H4] PASSED                                        [ 84%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-kv-cp-cache-H8] PASSED                                        [ 85%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-kv-cp-cache-H16] PASSED                                       [ 85%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-vk-cp-cache-H4] PASSED                                        [ 86%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-vk-cp-cache-H8] PASSED                                        [ 87%]
tests/test_gdr_unit.py::test_bwd_cp_cache[no_h0-vk-cp-cache-H16] PASSED                                       [ 88%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-kv-cp-cache-H4] PASSED                                           [ 89%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-kv-cp-cache-H8] PASSED                                           [ 90%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-kv-cp-cache-H16] PASSED                                          [ 90%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-vk-cp-cache-H4] PASSED                                           [ 91%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-vk-cp-cache-H8] PASSED                                           [ 92%]
tests/test_gdr_unit.py::test_bwd_cp_cache[h0-vk-cp-cache-H16] PASSED                                          [ 93%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_no_cp-fwd_no_cp-kv] PASSED                                  [ 94%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_no_cp-fwd_no_cp-vk] PASSED                                  [ 95%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_no_cp-fwd_cp-kv] PASSED                                     [ 95%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_no_cp-fwd_cp-vk] PASSED                                     [ 96%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_cp-fwd_no_cp-kv] PASSED                                     [ 97%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_cp-fwd_no_cp-vk] PASSED                                     [ 98%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_cp-fwd_cp-kv] PASSED                                        [ 99%]
tests/test_gdr_unit.py::test_mixed_cp_control[bwd_cp-fwd_cp-vk] PASSED                                        [100%]

================================================= warnings summary ==================================================
.venv/lib/python3.13/site-packages/tilelang/language/eager/builder.py:888: 2 warnings
tests/test_gdr_unit.py: 675 warnings
  /home/hayden/projects/FlashQLA/.venv/lib/python3.13/site-packages/tilelang/language/eager/builder.py:888: DeprecationWarning: Failing to pass a value to the 'type_params' parameter of 'typing._eval_type' is deprecated, as it leads to incorrect behaviour when calling typing._eval_type on a stringified annotation that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
    hints[name] = _eval_type(value, globalns=globalns, localns=localns)

.venv/lib/python3.13/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/hayden/projects/FlashQLA/.venv/lib/python3.13/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================== 120 passed, 691 warnings in 2654.69s (0:44:14) ==================================
~~~

</details>