### PR TITLE
Fix low-level API example for CP cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,15 @@ For separate forward and backward calls:
 from flash_qla import chunk_gated_delta_rule_fwd, chunk_gated_delta_rule_bwd
 
 # Forward
-g, A, o, h, final_state = chunk_gated_delta_rule_fwd(
-    q, k, v, g, beta, scale=scale, initial_state=h0, cu_seqlens=cu_seqlens
+g, A, o, h, final_state, cp_cache = chunk_gated_delta_rule_fwd(
+    q, k, v, g, beta, scale=scale, initial_state=h0, cu_seqlens=cu_seqlens,
+    enable_fwd_cp_cache=True,
 )
 
 # Backward
 dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
-    q, k, v, g, beta, A, do, dht=dht, scale=scale, initial_state=h0, cu_seqlens=cu_seqlens
+    q, k, v, g, beta, A, do, dht=dht, scale=scale, initial_state=h0,
+    cu_seqlens=cu_seqlens, cp_cache=cp_cache,
 )
 ```
 


### PR DESCRIPTION
## Summary

- unpack the `cp_cache` returned by `chunk_gated_delta_rule_fwd`
- enable the forward cache and pass it to `chunk_gated_delta_rule_bwd`

## Why

`chunk_gated_delta_rule_fwd` returns six values, but the README example only unpacks five. Running it raises `ValueError: too many values to unpack (expected 5)`. The updated example also demonstrates the intended cache handoff between separate forward and backward calls.

## Validation

- parsed the modified Python example with `ast.parse`
- verified the six unpacked values match the implementation return tuple
- verified `cp_cache` is accepted by the backward API
- ran `git diff --check`
