### PR TITLE
perf(gdr): reduce SM100 fused-backward register spilling

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_bwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/blackwell/fused_bwd.py
@@ -280,10 +280,10 @@ def tilelang_fused_chunk_gdr_bwd(
 
             tx = T.get_thread_binding()
 
-            PRODUCER_NREG = 64
-            CONSUMER_K_NREG = 136
-            CONSUMER_A_NREG = 136
-            CONSUMER_S_NREG = 176
+            PRODUCER_NREG = 72
+            CONSUMER_K_NREG = 144
+            CONSUMER_A_NREG = 144
+            CONSUMER_S_NREG = 152
 
             # Prefetch the last chunk of data
             if state_v_first:


### PR DESCRIPTION
# SM100 Fused Backward Register Rebalance

## Summary

- Set the Producer/K/A/S register caps to 72/144/144/152.
- Preserve the 65,536-register summed role budget per CTA.
- Reduce local-memory traffic from register spilling.

## Correctness Validation

- Production path: `python -m pytest -q tests/test_gdr_unit.py tests/test_function_signature.py -m 'not slow'` — 115 passed, 6 deselected.
- Slow determinism lane: `python -m pytest -q tests/test_gdr_unit.py -m slow` — 6 passed, 114 deselected.
- The register-only A/B candidate matched `dq`, `dk`, `dv`, `db`, `dg`, and `dh0` bitwise across 48 configurations.

## Isolated `fused_bwd` Performance Results (B200 / SM100)

All results in this section measure the isolated `fused_bwd` operator. They are not end-to-end backward measurements.

The timed region contains one `fused_bwd` kernel launch. Input preparation, auto-CP preprocessing, state construction, output allocation, and gradient postprocessing are excluded.

Used Torch 2.8.0+cu128 and TileLang 0.1.9 on one B200. Used three alternating CUDA Graph A/B pairs. Disabled auto-CP in both arms. Clocks were not fixed.

### Reviewer-Aligned Shapes

Used BF16, T=16384, D=128, and Hq=Hkv=64.

| Shape | `cu_seqlens` | Baseline | Candidate | Speedup |
| --- | --- | ---: | ---: | ---: |
| Single sequence | `[0,16384]` | 2.669 ms | 2.476 ms | 1.078x |
| Packed varlen | `[0,8192,16384]` | 1.394 ms | 1.289 ms | 1.082x |

The isolated `fused_bwd` geometric-mean speedup is 1.080x.

This agrees with the PR #39 reviewer result (<https://github.com/QwenLM/FlashQLA/pull/39#issuecomment-5422954809>): the isolated `fused_bwd` kernel is approximately 8–9% faster on both single-sequence and packed-varlen shapes.

### Expanded Isolated `fused_bwd` Test Matrix

Used BF16, B=1, total T=32768, D=128, and varlen seed 42.

| Hqk/Hv | 1 seq | 2 seq | 4 seq | 5 seq | 6 seq | 8 seq |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 16/16 | 1.066x | 1.067x | 1.070x | 1.071x | 1.057x | 1.064x |
| 4/16 | 1.039x | 1.040x | 1.056x | 1.053x | 1.074x | 1.074x |
| 12/12 | 1.057x | 1.063x | 1.081x | 1.078x | 1.049x | 1.061x |
| 4/12 | 1.063x | 1.057x | 1.070x | 1.047x | 1.060x | 1.062x |
| 8/8 | 1.036x | 1.053x | 1.066x | 1.058x | 1.054x | 1.060x |
| 4/8 | 1.049x | 1.058x | 1.064x | 1.066x | 1.062x | 1.069x |
| 4/4 | 1.044x | 1.046x | 1.047x | 1.051x | 1.045x | 1.046x |

- Single-sequence geometric mean: 1.051x
- Packed-varlen geometric mean: 1.060x
- Overall geometric mean: 1.058x
- Improved cases: 42 / 42

## Isolated `fused_bwd` NCU Register-Spill Reduction

Profiled the same isolated `fused_bwd` operator with NCU 2026.2.1.

Used:

- BF16
- Packed T=16384
- Hq=Hkv=64
- D=128
- `cu_seqlens=[0,8192,16384]`
- auto-CP disabled

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Dynamic local LD instructions | 3,559,680 | 2,707,712 | -23.93% |
| Dynamic local ST instructions | 2,518,144 | 1,599,616 | -36.48% |
| Dynamic local LD + ST | 6,077,824 | 4,307,328 | -29.13% |
| SourceCounters local register spilling | 5.977984 MB | 4.240256 MB | -29.07% |
| L1TEX local-memory requests | 6,653,440 | 4,307,328 | -35.26% |
| SourceCounters shared register spilling | 16.768 KB | 16.768 KB | 0.00% |
| Registers per thread / occupancy limit | 128 / 1 block | 128 / 1 block | unchanged |

Consumer-S accounts for 1.98% of the baseline local sectors. Consumer-K/A account for 93.61%.

The new allocation moves register capacity toward the spilling consumers. It reduces local spilling without reverting the high-precision `dg` fix.

## Scope

- Change only the four role-local register caps in `blackwell/fused_bwd.py`.
- Keep arithmetic, barriers, SMEM/TMEM usage, launch geometry, and auto-CP unchanged.